### PR TITLE
Enhance landing page blog navigator

### DIFF
--- a/components/posts/post-selector.tsx
+++ b/components/posts/post-selector.tsx
@@ -8,47 +8,69 @@ interface PostSelectorProps {
   onSelectPost: (index: number) => void;
 }
 
+function formatShortDate(dateString: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(dateString));
+}
+
 export default function PostSelector({
   posts,
   selectedPostIndex,
   onSelectPost,
 }: PostSelectorProps) {
+  const activePost = posts[selectedPostIndex];
+
   return (
-    <div className="w-full h-full flex flex-col min-h-0">
-      <h3 className="text-xl font-semibold mb-4 text-foreground shrink-0">
-        All Posts
-      </h3>
-      <div className="relative">
-        <select
-          value={selectedPostIndex}
-          onChange={(e) => onSelectPost(Number(e.target.value))}
-          className="appearance-none w-full p-3 pr-10 rounded-t-lg border border-border border-b-0 bg-background text-foreground focus:outline-none focus:border-accent transition-colors duration-200 cursor-pointer"
-        >
-          {posts.map((post, index) => (
-            <option key={post.slug+index} value={index}>
-              {post.title.length > 60
-                ? `${post.title.slice(0, 60)}...`
-                : post.title}
-            </option>
-          ))}
-        </select>
-        <div className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none">
-          <svg
-            className="w-5 h-5 text-foreground"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 9l-7 7-7-7"
-            />
-          </svg>
+    <section
+      className="post-navigator mb-4 overflow-hidden rounded-xl border border-border bg-surface/70 shadow-sm"
+      aria-label="Blog post navigator"
+    >
+      <div className="flex items-center justify-between gap-4 border-b border-border px-4 py-3 md:px-5">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-accent">
+            Blog navigator
+          </p>
+          <h3 className="mt-1 text-lg font-semibold text-foreground md:text-xl">
+            {activePost?.title ?? "All posts"}
+          </h3>
         </div>
+        <span className="shrink-0 rounded-full border border-border bg-background px-3 py-1 text-xs font-medium text-muted">
+          {selectedPostIndex + 1}/{posts.length}
+        </span>
       </div>
-    </div>
+
+      <div
+        className="post-navigator__rail"
+        role="listbox"
+        aria-label="Choose a blog post"
+      >
+        {posts.map((post, index) => {
+          const isSelected = index === selectedPostIndex;
+
+          return (
+            <button
+              key={`${post.slug}${index}`}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              className="post-navigator__item"
+              onClick={() => onSelectPost(index)}
+            >
+              <span className="post-navigator__index">
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <span className="post-navigator__content">
+                <span className="post-navigator__title">{post.title}</span>
+                <span className="post-navigator__meta">
+                  {formatShortDate(post.pubDate)}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
   );
 }

--- a/components/posts/post.css
+++ b/components/posts/post.css
@@ -42,3 +42,141 @@
 
 
 
+
+/* Landing-page blog navigator */
+.post-navigator {
+  --navigator-item-width: clamp(9rem, 22vw, 15rem);
+}
+
+.post-navigator__rail {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding: 0.75rem;
+  scroll-snap-type: x proximity;
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent-light) transparent;
+}
+
+.post-navigator__rail::-webkit-scrollbar {
+  height: 0.5rem;
+}
+
+.post-navigator__rail::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--accent-light) 70%, transparent);
+  border-radius: 999px;
+}
+
+.post-navigator__item {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.75rem;
+  width: var(--navigator-item-width);
+  min-width: var(--navigator-item-width);
+  min-height: 4.75rem;
+  scroll-snap-align: center;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--background);
+  color: var(--foreground);
+  padding: 0.8rem;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    width 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    min-width 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 180ms ease,
+    background 180ms ease,
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.post-navigator__item::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at top left,
+    color-mix(in srgb, var(--accent-light) 34%, transparent),
+    transparent 55%
+  );
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+.post-navigator__item:hover,
+.post-navigator__item:focus-visible,
+.post-navigator__item[aria-selected="true"] {
+  width: calc(var(--navigator-item-width) * 1.35);
+  min-width: calc(var(--navigator-item-width) * 1.35);
+  border-color: var(--accent);
+  box-shadow: 0 14px 30px color-mix(in srgb, var(--foreground) 12%, transparent);
+  transform: translateY(-2px);
+}
+
+.post-navigator__item:hover::before,
+.post-navigator__item:focus-visible::before,
+.post-navigator__item[aria-selected="true"]::before {
+  opacity: 1;
+}
+
+.post-navigator__item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.post-navigator__index,
+.post-navigator__content {
+  position: relative;
+  z-index: 1;
+}
+
+.post-navigator__index {
+  display: grid;
+  place-items: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  transition: background 180ms ease, color 180ms ease;
+}
+
+.post-navigator__item[aria-selected="true"] .post-navigator__index,
+.post-navigator__item:hover .post-navigator__index,
+.post-navigator__item:focus-visible .post-navigator__index {
+  background: var(--accent);
+  color: white;
+}
+
+.post-navigator__content {
+  min-width: 0;
+}
+
+.post-navigator__title {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  font-size: 0.9rem;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.post-navigator__meta {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+@media (max-width: 640px) {
+  .post-navigator {
+    --navigator-item-width: 13.5rem;
+  }
+}


### PR DESCRIPTION
### Motivation

- Replace the simple dropdown post selector on the landing page with a more discoverable, touch-friendly blog post navigator that surfaces the active post and makes it faster to switch posts.

### Description

- Replace the select-based dropdown with a horizontal `post-navigator` component that shows the active post title and a position counter. 
- Add `formatShortDate` and render numbered, focusable `button` items with `role="option"` inside a `role="listbox"` rail for better accessibility and keyboard/touch interaction. 
- Add a new CSS block in `components/posts/post.css` that implements the horizontal rail, scroll snapping, custom scrollbar, responsive item sizing, hover/focus/active expansion and visual accenting. 
- Keep the existing `PostStack`/`PostCard` flow intact and wire navigator selection to the same `selectedPostIndex` callback.

### Testing

- Ran TypeScript checks with `npx tsc --noEmit` and they passed.  
- Ran `git diff --check` (style/format checks) and it passed.  
- Started the dev server and confirmed the app responded with `HTTP/1.1 200 OK` via `curl -I http://localhost:3000`.  
- Ran `npm run build` which failed in this environment because `next/font` could not fetch the `Inter` font from Google Fonts (network/font fetch issue), so a production build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4983f9803c832698a5f6149bd0dfa7)