### PR TITLE
Revise personal website experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,19 @@ Deployed on [Vercel](https://vercel.com).
 ### Current location
 
 The location pill reads one city-level `current_location` record from Vercel
-Edge Config and combines it with current conditions from Open-Meteo. Location
-reads expire within 60 seconds; weather is cached separately by rounded
-coordinates for several minutes. If the store is unavailable or contains an
-invalid value, Lisbon is used as the home base.
+Global Config (formerly Edge Config) and combines it with current conditions
+from Open-Meteo. Location reads expire within 60 seconds; weather is cached
+separately by rounded coordinates for several minutes. If the store is
+unavailable or contains an invalid value, Lisbon is used as the home base.
 
-Create an Edge Config store in Vercel, connect it to this project, and configure:
+Create a Global Config store in Vercel, connect it to this project, and configure:
 
 | Variable | Purpose |
 | --- | --- |
-| `EDGE_CONFIG` | Read connection string injected by the Edge Config connection |
-| `EDGE_CONFIG_ID` | Store ID used by the update route |
-| `EDGE_CONFIG_WRITE_TOKEN` | Vercel access token used only by the server-side write route |
-| `EDGE_CONFIG_TEAM_ID` | Optional team ID for a team-owned store |
+| `GLOBAL_CONFIG` | Read connection string injected by the Global Config connection |
+| `GLOBAL_CONFIG_ID` | Store ID used by the update route |
+| `GLOBAL_CONFIG_WRITE_TOKEN` | Sensitive, project-scoped Vercel access token used only by the server-side write route |
+| `GLOBAL_CONFIG_TEAM_ID` | Optional team ID for a team-owned store |
 | `LOCATION_UPDATE_SECRET` | A separate, random secret known by the iPhone Shortcut |
 
 The initial store item is optional. When present, its key is
@@ -63,8 +63,9 @@ The initial store item is optional. When present, its key is
 
 The protected endpoint accepts `POST /api/location/update` with a bearer token.
 It validates city and country names, rounds coordinates to two decimals, and
-upserts the record through Vercel's authenticated Edge Config API. Never expose
-`EDGE_CONFIG_WRITE_TOKEN` to the Shortcut.
+upserts the record through Vercel's authenticated Global Config API. Never expose
+`GLOBAL_CONFIG_WRITE_TOKEN` to the Shortcut. Give the token access only to this
+project, set an expiration, and record its rotation date in Vercel.
 
 #### iPhone Shortcut
 
@@ -73,7 +74,7 @@ Create a Shortcut named **Update website location**:
 1. Add **Get Current Location**.
 2. Read **City**, **Country**, **Latitude**, and **Longitude** from that location.
 3. Add **Get Contents of URL** using
-   `https://personal-website-hugodemenez.vercel.app/api/location/update`.
+   `https://www.hugodemenez.fr/api/location/update`.
 4. Choose `POST`, set the request body to JSON, and add the four fields as
    `city`, `country`, `latitude`, and `longitude`.
 5. Add an `Authorization` header whose value is

--- a/README.md
+++ b/README.md
@@ -29,6 +29,62 @@ npm run dev
 
 Deployed on [Vercel](https://vercel.com).
 
+### Current location
+
+The location pill reads one city-level `current_location` record from Vercel
+Edge Config and combines it with current conditions from Open-Meteo. Location
+reads expire within 60 seconds; weather is cached separately by rounded
+coordinates for several minutes. If the store is unavailable or contains an
+invalid value, Lisbon is used as the home base.
+
+Create an Edge Config store in Vercel, connect it to this project, and configure:
+
+| Variable | Purpose |
+| --- | --- |
+| `EDGE_CONFIG` | Read connection string injected by the Edge Config connection |
+| `EDGE_CONFIG_ID` | Store ID used by the update route |
+| `EDGE_CONFIG_WRITE_TOKEN` | Vercel access token used only by the server-side write route |
+| `EDGE_CONFIG_TEAM_ID` | Optional team ID for a team-owned store |
+| `LOCATION_UPDATE_SECRET` | A separate, random secret known by the iPhone Shortcut |
+
+The initial store item is optional. When present, its key is
+`current_location` and its value has this shape:
+
+```json
+{
+  "version": 1,
+  "city": "Lisbon",
+  "country": "Portugal",
+  "latitude": 38.72,
+  "longitude": -9.14,
+  "updatedAt": "2026-08-01T08:00:00.000Z"
+}
+```
+
+The protected endpoint accepts `POST /api/location/update` with a bearer token.
+It validates city and country names, rounds coordinates to two decimals, and
+upserts the record through Vercel's authenticated Edge Config API. Never expose
+`EDGE_CONFIG_WRITE_TOKEN` to the Shortcut.
+
+#### iPhone Shortcut
+
+Create a Shortcut named **Update website location**:
+
+1. Add **Get Current Location**.
+2. Read **City**, **Country**, **Latitude**, and **Longitude** from that location.
+3. Add **Get Contents of URL** using
+   `https://personal-website-hugodemenez.vercel.app/api/location/update`.
+4. Choose `POST`, set the request body to JSON, and add the four fields as
+   `city`, `country`, `latitude`, and `longitude`.
+5. Add an `Authorization` header whose value is
+   `Bearer <LOCATION_UPDATE_SECRET>`.
+6. If the response's `ok` value is not true, show a failure notification.
+
+In the Shortcuts **Automation** tab, create a daily 8:00 AM automation, select
+this Shortcut, enable **Run Immediately**, and disable success notifications.
+Run it manually once before enabling the schedule and confirm the endpoint
+returns `200` with the city and `updatedAt` fields.
+
 ### Spotify authorization
 
 The footer reads user-specific Spotify data with the Authorization Code flow. Configure

--- a/app/api/location/update/route.test.ts
+++ b/app/api/location/update/route.test.ts
@@ -48,17 +48,17 @@ test("rejects malformed JSON and invalid coordinates", async () => {
   );
 });
 
-test("returns 503 when Edge Config is unavailable", async () => {
+test("returns 503 when Global Config is unavailable", async () => {
   process.env.LOCATION_UPDATE_SECRET = "shortcut-secret";
-  delete process.env.EDGE_CONFIG_ID;
-  delete process.env.EDGE_CONFIG_WRITE_TOKEN;
+  delete process.env.GLOBAL_CONFIG_ID;
+  delete process.env.GLOBAL_CONFIG_WRITE_TOKEN;
   assert.equal((await POST(request(validPayload))).status, 503);
 });
 
 test("writes the rounded location and returns its public summary", async () => {
   process.env.LOCATION_UPDATE_SECRET = "shortcut-secret";
-  process.env.EDGE_CONFIG_ID = "ecfg_test";
-  process.env.EDGE_CONFIG_WRITE_TOKEN = "write-token";
+  process.env.GLOBAL_CONFIG_ID = "ecfg_test";
+  process.env.GLOBAL_CONFIG_WRITE_TOKEN = "write-token";
 
   const originalFetch = globalThis.fetch;
   let sentBody: unknown;
@@ -94,10 +94,10 @@ test("writes the rounded location and returns its public summary", async () => {
   }
 });
 
-test("returns 503 when the Edge Config write fails", async () => {
+test("returns 503 when the Global Config write fails", async () => {
   process.env.LOCATION_UPDATE_SECRET = "shortcut-secret";
-  process.env.EDGE_CONFIG_ID = "ecfg_test";
-  process.env.EDGE_CONFIG_WRITE_TOKEN = "write-token";
+  process.env.GLOBAL_CONFIG_ID = "ecfg_test";
+  process.env.GLOBAL_CONFIG_WRITE_TOKEN = "write-token";
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () => new Response(null, { status: 500 });
 

--- a/app/api/location/update/route.test.ts
+++ b/app/api/location/update/route.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { POST } from "./route";
+
+const validPayload = {
+  city: "Paris",
+  country: "France",
+  latitude: 48.8566,
+  longitude: 2.3522,
+};
+
+function request(payload: unknown, secret = "shortcut-secret") {
+  return new Request("http://localhost/api/location/update", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${secret}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+test("rejects missing and incorrect authorization", async () => {
+  process.env.LOCATION_UPDATE_SECRET = "shortcut-secret";
+  const missing = await POST(
+    new Request("http://localhost/api/location/update", { method: "POST" })
+  );
+  assert.equal(missing.status, 401);
+  assert.equal((await POST(request(validPayload, "wrong"))).status, 401);
+});
+
+test("rejects malformed JSON and invalid coordinates", async () => {
+  process.env.LOCATION_UPDATE_SECRET = "shortcut-secret";
+  const malformed = await POST(
+    new Request("http://localhost/api/location/update", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer shortcut-secret",
+        "content-type": "application/json",
+      },
+      body: "{",
+    })
+  );
+  assert.equal(malformed.status, 400);
+  assert.equal(
+    (await POST(request({ ...validPayload, latitude: 100 }))).status,
+    400
+  );
+});
+
+test("returns 503 when Edge Config is unavailable", async () => {
+  process.env.LOCATION_UPDATE_SECRET = "shortcut-secret";
+  delete process.env.EDGE_CONFIG_ID;
+  delete process.env.EDGE_CONFIG_WRITE_TOKEN;
+  assert.equal((await POST(request(validPayload))).status, 503);
+});
+
+test("writes the rounded location and returns its public summary", async () => {
+  process.env.LOCATION_UPDATE_SECRET = "shortcut-secret";
+  process.env.EDGE_CONFIG_ID = "ecfg_test";
+  process.env.EDGE_CONFIG_WRITE_TOKEN = "write-token";
+
+  const originalFetch = globalThis.fetch;
+  let sentBody: unknown;
+  globalThis.fetch = async (_input, init) => {
+    sentBody = JSON.parse(String(init?.body));
+    return new Response(null, { status: 200 });
+  };
+
+  try {
+    const response = await POST(request(validPayload));
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      ok: boolean;
+      location: { city: string; updatedAt: string };
+    };
+    assert.equal(body.ok, true);
+    assert.equal(body.location.city, "Paris");
+    assert.ok(!Number.isNaN(Date.parse(body.location.updatedAt)));
+    assert.deepEqual(
+      (sentBody as { items: Array<{ value: { latitude: number; longitude: number } }> })
+        .items[0].value,
+      {
+        version: 1,
+        city: "Paris",
+        country: "France",
+        latitude: 48.86,
+        longitude: 2.35,
+        updatedAt: body.location.updatedAt,
+      }
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("returns 503 when the Edge Config write fails", async () => {
+  process.env.LOCATION_UPDATE_SECRET = "shortcut-secret";
+  process.env.EDGE_CONFIG_ID = "ecfg_test";
+  process.env.EDGE_CONFIG_WRITE_TOKEN = "write-token";
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(null, { status: 500 });
+
+  try {
+    assert.equal((await POST(request(validPayload))).status, 503);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/app/api/location/update/route.ts
+++ b/app/api/location/update/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import {
+  createEdgeConfigWriteRequest,
+  hasValidBearerToken,
+  parseLocationUpdate,
+} from "@/server/location-data";
+
+export const runtime = "nodejs";
+
+function json(body: object, status: number) {
+  return NextResponse.json(body, {
+    status,
+    headers: { "cache-control": "no-store" },
+  });
+}
+
+export async function POST(request: Request) {
+  if (
+    !hasValidBearerToken(
+      request.headers.get("authorization"),
+      process.env.LOCATION_UPDATE_SECRET
+    )
+  ) {
+    return json({ ok: false, error: "Unauthorized" }, 401);
+  }
+
+  const contentLength = Number(request.headers.get("content-length") ?? 0);
+  if (contentLength > 4_096) {
+    return json({ ok: false, error: "Invalid location payload" }, 400);
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return json({ ok: false, error: "Invalid location payload" }, 400);
+  }
+
+  const location = parseLocationUpdate(payload);
+  if (!location) {
+    return json({ ok: false, error: "Invalid location payload" }, 400);
+  }
+
+  const writeRequest = createEdgeConfigWriteRequest(location, {
+    EDGE_CONFIG_ID: process.env.EDGE_CONFIG_ID,
+    EDGE_CONFIG_WRITE_TOKEN: process.env.EDGE_CONFIG_WRITE_TOKEN,
+    EDGE_CONFIG_TEAM_ID: process.env.EDGE_CONFIG_TEAM_ID,
+  });
+  if (!writeRequest) {
+    return json({ ok: false, error: "Location storage unavailable" }, 503);
+  }
+
+  try {
+    const response = await fetch(writeRequest.url, writeRequest.init);
+    if (!response.ok) throw new Error("Edge Config write failed");
+  } catch {
+    console.error("Unable to update the current location in Edge Config");
+    return json({ ok: false, error: "Location storage unavailable" }, 503);
+  }
+
+  return json(
+    {
+      ok: true,
+      location: { city: location.city, updatedAt: location.updatedAt },
+    },
+    200
+  );
+}

--- a/app/api/location/update/route.ts
+++ b/app/api/location/update/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import {
-  createEdgeConfigWriteRequest,
+  createGlobalConfigWriteRequest,
   hasValidBearerToken,
   parseLocationUpdate,
 } from "@/server/location-data";
@@ -41,10 +41,10 @@ export async function POST(request: Request) {
     return json({ ok: false, error: "Invalid location payload" }, 400);
   }
 
-  const writeRequest = createEdgeConfigWriteRequest(location, {
-    EDGE_CONFIG_ID: process.env.EDGE_CONFIG_ID,
-    EDGE_CONFIG_WRITE_TOKEN: process.env.EDGE_CONFIG_WRITE_TOKEN,
-    EDGE_CONFIG_TEAM_ID: process.env.EDGE_CONFIG_TEAM_ID,
+  const writeRequest = createGlobalConfigWriteRequest(location, {
+    GLOBAL_CONFIG_ID: process.env.GLOBAL_CONFIG_ID,
+    GLOBAL_CONFIG_WRITE_TOKEN: process.env.GLOBAL_CONFIG_WRITE_TOKEN,
+    GLOBAL_CONFIG_TEAM_ID: process.env.GLOBAL_CONFIG_TEAM_ID,
   });
   if (!writeRequest) {
     return json({ ok: false, error: "Location storage unavailable" }, 503);
@@ -52,9 +52,9 @@ export async function POST(request: Request) {
 
   try {
     const response = await fetch(writeRequest.url, writeRequest.init);
-    if (!response.ok) throw new Error("Edge Config write failed");
+    if (!response.ok) throw new Error("Global Config write failed");
   } catch {
-    console.error("Unable to update the current location in Edge Config");
+    console.error("Unable to update the current location in Global Config");
     return json({ ok: false, error: "Location storage unavailable" }, 503);
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -119,6 +119,89 @@ dialog::backdrop {
   }
 }
 
+/* Writing artwork deck: stack forward, peel the top card away in reverse. */
+@keyframes artworkStackIn {
+  from {
+    filter: blur(6px);
+    opacity: 0.55;
+    transform: translateY(18%) scale(0.94);
+  }
+  to {
+    filter: blur(0);
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes artworkStackUnder {
+  from {
+    transform: translateY(0) scale(1);
+  }
+  to {
+    transform: translateY(-1.5%) scale(0.975);
+  }
+}
+
+@keyframes artworkDestackOut {
+  from {
+    filter: blur(0);
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    filter: blur(6px);
+    opacity: 0;
+    transform: translateY(18%) scale(0.94);
+  }
+}
+
+@keyframes artworkDestackReveal {
+  from {
+    transform: translateY(-1.5%) scale(0.975);
+  }
+  to {
+    transform: translateY(0) scale(1);
+  }
+}
+
+.artwork-stack-in,
+.artwork-stack-under,
+.artwork-destack-out,
+.artwork-destack-reveal {
+  transform-origin: center top;
+  will-change: filter, opacity, transform;
+}
+
+.artwork-stack-in,
+.artwork-stack-under {
+  animation-duration: 240ms;
+  animation-fill-mode: both;
+  animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.artwork-stack-in {
+  animation-name: artworkStackIn;
+}
+
+.artwork-stack-under {
+  animation-name: artworkStackUnder;
+}
+
+.artwork-destack-out,
+.artwork-destack-reveal {
+  animation-duration: 200ms;
+  animation-fill-mode: both;
+  animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.artwork-destack-out {
+  animation-name: artworkDestackOut;
+}
+
+.artwork-destack-reveal {
+  animation-name: artworkDestackReveal;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -144,5 +227,12 @@ dialog::backdrop {
     100% {
       opacity: 1;
     }
+  }
+
+  .artwork-stack-in,
+  .artwork-stack-under,
+  .artwork-destack-out,
+  .artwork-destack-reveal {
+    animation: none;
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,11 @@
 import GeneratedContent from "@/components/generated-content";
 import SubstackPosts from "@/components/posts/substack-posts";
-import { SiteFooter } from "../components/site-footer";
 
 export default async function Home() {
   return (
     <main className="flex flex-col gap-8 mt-4">
       <GeneratedContent />
       <SubstackPosts />
-      <SiteFooter />
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,14 @@
 import GeneratedContent from "@/components/generated-content";
 import SubstackPosts from "@/components/posts/substack-posts";
+import { Suspense } from "react";
 
 export default async function Home() {
   return (
     <main className="flex flex-col gap-8 mt-4">
-      <GeneratedContent />
-      <SubstackPosts />
+      <Suspense fallback={null}>
+        <GeneratedContent />
+        <SubstackPosts />
+      </Suspense>
     </main>
   );
 }

--- a/components/generated-content.tsx
+++ b/components/generated-content.tsx
@@ -53,15 +53,15 @@ export default async function GeneratedContent() {
   return (
     <section className="space-y-4 text-muted">
       <div className="mb-7">
+        <div className="mb-3 flex">
+          <WeatherPill weather={weather} />
+        </div>
         <h1 className="font-serif text-5xl leading-[0.95] tracking-[-0.04em] text-foreground sm:text-6xl">
           Hugo Demenez
         </h1>
-        <div className="mt-2 flex items-end gap-2.5">
-          <p className="font-serif text-xl tracking-[-0.02em] text-muted">
-            Software writer
-          </p>
-          <WeatherPill weather={weather} />
-        </div>
+        <p className="mt-2 font-serif text-xl tracking-[-0.02em] text-muted">
+          Software writer
+        </p>
       </div>
       <p className="leading-relaxed">
         I build practical software for trading and analytics—journals, network

--- a/components/generated-content.tsx
+++ b/components/generated-content.tsx
@@ -56,7 +56,7 @@ export default async function GeneratedContent() {
         <h1 className="font-serif text-5xl leading-[0.95] tracking-[-0.04em] text-foreground sm:text-6xl">
           Hugo Demenez
         </h1>
-        <div className="mt-2 flex items-baseline gap-2.5">
+        <div className="mt-2 flex items-end gap-2.5">
           <p className="font-serif text-xl tracking-[-0.02em] text-muted">
             Software writer
           </p>

--- a/components/generated-content.tsx
+++ b/components/generated-content.tsx
@@ -56,7 +56,7 @@ export default async function GeneratedContent() {
         <h1 className="font-serif text-5xl leading-[0.95] tracking-[-0.04em] text-foreground sm:text-6xl">
           Hugo Demenez
         </h1>
-        <div className="mt-2 flex items-center gap-2.5">
+        <div className="mt-2 flex items-baseline gap-2.5">
           <p className="font-serif text-xl tracking-[-0.02em] text-muted">
             Software writer
           </p>

--- a/components/generated-content.tsx
+++ b/components/generated-content.tsx
@@ -1,5 +1,6 @@
 import { getLisbonWeather } from "@/server/location";
 import { getSpotifyData } from "@/server/spotify";
+import WeatherPill from "@/components/weather-pill";
 
 function XIcon() {
   return (
@@ -55,38 +56,12 @@ export default async function GeneratedContent() {
         <h1 className="font-serif text-5xl leading-[0.95] tracking-[-0.04em] text-foreground sm:text-6xl">
           Hugo Demenez
         </h1>
-        <p className="mt-2 font-serif text-xl tracking-[-0.02em] text-muted">
-          Software writer
-        </p>
-      </div>
-      <div>
-        <div
-          aria-label="Current location and weather"
-          className="flex w-full items-center justify-center gap-2 rounded-full bg-surface px-4 py-3 text-[clamp(0.8rem,3.5vw,1.125rem)] tracking-[-0.02em] text-muted sm:gap-3 sm:px-6"
-        >
-          <span className="whitespace-nowrap">{weather?.location ?? "Lisbon"}</span>
-          <span aria-hidden="true" className="text-foreground/30">
-            •
-          </span>
-          <span className="whitespace-nowrap">{weather?.time ?? "Local time"}</span>
-          <span aria-hidden="true" className="text-foreground/30">
-            •
-          </span>
-          <span className="whitespace-nowrap">
-            {weather ? `${weather.temperature}°C, ${weather.condition}` : "Weather unavailable"}
-          </span>
+        <div className="mt-2 flex items-center gap-2.5">
+          <p className="font-serif text-xl tracking-[-0.02em] text-muted">
+            Software writer
+          </p>
+          <WeatherPill weather={weather} />
         </div>
-        <p className="mt-2 text-center text-xs text-muted/60">
-          Weather by{" "}
-          <a
-            className="underline decoration-border underline-offset-2 transition-colors hover:text-muted"
-            href="https://open-meteo.com/"
-            rel="noreferrer"
-            target="_blank"
-          >
-            Open-Meteo
-          </a>
-        </p>
       </div>
       <p className="leading-relaxed">
         I build practical software for trading and analytics—journals, network

--- a/components/generated-content.tsx
+++ b/components/generated-content.tsx
@@ -1,18 +1,145 @@
-export default function GeneratedContent() {
+import { getLisbonWeather } from "@/server/location";
+import { getSpotifyData } from "@/server/spotify";
+
+function XIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-2.5 shrink-0 fill-current"
+      viewBox="0 0 1200 1227"
+    >
+      <path d="M714.163 519.284 1160.89 0h-105.86L667.137 450.887 357.328 0H0l468.492 681.821L0 1226.37h105.866l409.625-476.152 327.181 476.152H1200L714.137 519.284h.026ZM569.165 687.828l-47.468-67.894L144.011 79.694h162.604l304.797 435.991 47.468 67.894 396.2 566.721H892.476L569.165 687.854v-.026Z" />
+    </svg>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-3 shrink-0 fill-current"
+      viewBox="0 0 98 96"
+    >
+      <path d="M41.44 69.385C28.807 67.854 19.906 58.762 19.906 46.99c0-4.785 1.723-9.953 4.594-13.398-1.244-3.158-1.053-9.858.383-12.633 3.828-.479 8.996 1.531 12.058 4.307 3.637-1.149 7.465-1.723 12.155-1.723s8.517.574 11.963 1.627c2.966-2.68 8.23-4.69 12.058-4.211 1.34 2.584 1.531 9.283.287 12.537 3.063 3.637 4.69 8.518 4.69 13.494 0 11.772-8.901 20.672-21.725 22.3 3.254 2.104 5.455 6.698 5.455 11.962v9.953c0 2.871 2.393 4.498 5.264 3.35C84.41 87.95 98 70.628 98 49.191 98 22.107 75.988 0 48.904 0 21.82 0 0 22.107 0 49.191c0 21.247 13.494 38.856 31.678 45.46 2.584.957 5.072-.766 5.072-3.35v-7.657c-1.34.574-3.062.957-4.594.957-6.316 0-10.048-3.445-12.728-9.857-1.053-2.584-2.201-4.115-4.402-4.402-1.149-.096-1.532-.574-1.532-1.149 0-1.148 1.914-2.01 3.828-2.01 2.776 0 5.168 1.723 7.657 5.264 1.914 2.776 3.923 4.02 6.316 4.02s3.924-.861 6.125-3.062c1.627-1.627 2.871-3.063 4.02-4.02Z" />
+    </svg>
+  );
+}
+
+function SpotifyIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="mr-1 inline size-3 -translate-y-px fill-current"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 0a12 12 0 1 0 0 24 12 12 0 0 0 0-24Zm5.5 17.3a.75.75 0 0 1-1.03.25c-2.82-1.72-6.37-2.11-10.55-1.16a.75.75 0 1 1-.33-1.46c4.57-1.04 8.5-.59 11.66 1.34.36.22.47.68.25 1.03Zm1.47-3.27a.94.94 0 0 1-1.29.31c-3.23-1.98-8.15-2.55-11.96-1.4a.94.94 0 1 1-.54-1.8c4.36-1.31 9.78-.68 13.48 1.6.44.27.58.85.31 1.29Zm.13-3.4C15.23 8.33 8.84 8.12 5.14 9.24a1.13 1.13 0 1 1-.65-2.16c4.25-1.28 11.32-1.03 15.76 1.6a1.13 1.13 0 0 1-1.15 1.95Z" />
+    </svg>
+  );
+}
+
+const socialLinkClass =
+  "inline-flex items-center gap-1 align-baseline font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:text-accent";
+const musicLinkClass =
+  "font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:text-accent";
+
+export default async function GeneratedContent() {
+  const [weather, spotify] = await Promise.all([
+    getLisbonWeather(),
+    getSpotifyData(),
+  ]);
+  const track = spotify.recentTrack;
+
   return (
     <section className="space-y-4 text-muted">
+      <div className="mb-7">
+        <h1 className="font-serif text-5xl leading-[0.95] tracking-[-0.04em] text-foreground sm:text-6xl">
+          Hugo Demenez
+        </h1>
+        <p className="mt-2 font-serif text-xl tracking-[-0.02em] text-muted">
+          Software writer
+        </p>
+      </div>
+      <div>
+        <div
+          aria-label="Current location and weather"
+          className="flex w-full items-center justify-center gap-2 rounded-full bg-surface px-4 py-3 text-[clamp(0.8rem,3.5vw,1.125rem)] tracking-[-0.02em] text-muted sm:gap-3 sm:px-6"
+        >
+          <span className="whitespace-nowrap">{weather?.location ?? "Lisbon"}</span>
+          <span aria-hidden="true" className="text-foreground/30">
+            •
+          </span>
+          <span className="whitespace-nowrap">{weather?.time ?? "Local time"}</span>
+          <span aria-hidden="true" className="text-foreground/30">
+            •
+          </span>
+          <span className="whitespace-nowrap">
+            {weather ? `${weather.temperature}°C, ${weather.condition}` : "Weather unavailable"}
+          </span>
+        </div>
+        <p className="mt-2 text-center text-xs text-muted/60">
+          Weather by{" "}
+          <a
+            className="underline decoration-border underline-offset-2 transition-colors hover:text-muted"
+            href="https://open-meteo.com/"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Open-Meteo
+          </a>
+        </p>
+      </div>
       <p className="leading-relaxed">
-        I build practical software around trading, analytics, and the small
-        workflows that compound when they are measured carefully.
+        I build practical software for trading and analytics—journals, network
+        dashboards, strategy research, and small tools that make difficult
+        decisions easier to review.
       </p>
       <p className="leading-relaxed">
-        My current work focuses on trading journals, network dashboards,
-        automated strategy research, and the operator tools needed to make
-        complex decisions easier to review.
+        I write about the work as I go: building products, staying focused,
+        discretionary trading, and turning rough ideas into useful systems.
+        {track ? (
+          <>
+            {" "}Most days have a soundtrack; lately it has been{" "}
+            <a
+              className={musicLinkClass}
+              href={track.url}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <SpotifyIcon />
+              {track.name} by {track.artist}
+            </a>
+            .
+          </>
+        ) : null}
       </p>
       <p className="leading-relaxed">
-        I also write about building products, staying focused, discretionary
-        trading, and the craft of turning rough ideas into usable systems.
+        I keep a small social footprint. On X, I’m{" "}
+        <a
+          className={socialLinkClass}
+          href="https://x.com/hugodemenez"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <XIcon />
+          @hugodemenez
+        </a>
+        —mostly reposting things worth keeping and occasionally sharing a
+        thought of my own.
+      </p>
+      <p className="leading-relaxed">
+        The work itself is less private: I build in public on GitHub as{" "}
+        <span className="whitespace-nowrap">
+          <a
+            className={socialLinkClass}
+            href="https://github.com/hugodemenez"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <GitHubIcon />
+            hugodemenez
+          </a>
+          .
+        </span>
       </p>
     </section>
   );

--- a/components/generated-content.tsx
+++ b/components/generated-content.tsx
@@ -1,6 +1,7 @@
-import { getLisbonWeather } from "@/server/location";
+import { getCurrentLocationWeather } from "@/server/location";
 import { getSpotifyData } from "@/server/spotify";
 import WeatherPill from "@/components/weather-pill";
+import { cacheLife } from "next/cache";
 
 function XIcon() {
   return (
@@ -44,8 +45,11 @@ const musicLinkClass =
   "font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:text-accent";
 
 export default async function GeneratedContent() {
+  "use cache";
+  cacheLife("seconds");
+
   const [weather, spotify] = await Promise.all([
-    getLisbonWeather(),
+    getCurrentLocationWeather(),
     getSpotifyData(),
   ]);
   const track = spotify.recentTrack;

--- a/components/posts/post-visualizer.tsx
+++ b/components/posts/post-visualizer.tsx
@@ -1,18 +1,26 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { SubstackPost } from "@/types/substack-post";
-import PostStack from "./post-stack";
-import PostTable from "./post-selector";
 
 interface PostsVisualizerProps {
   posts: SubstackPost[];
 }
 
+const IMAGE_SIZES = "(max-width: 768px) 92vw, 700px";
+
+function getPostHref(post: SubstackPost): string {
+  return post.slug ? `/posts/${post.slug}` : post.link;
+}
+
 export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
   const [selectedPostIndex, setSelectedPostIndex] = useState(0);
+  const [isWritingVisible, setIsWritingVisible] = useState(false);
+  const sectionRef = useRef<HTMLElement>(null);
+  const postRefs = useRef<Array<HTMLLIElement | null>>([]);
 
-  // Sort posts by date descending (latest first)
   const sortedPosts = useMemo(
     () =>
       [...posts].sort(
@@ -21,25 +29,215 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
     [posts]
   );
 
-  // Reset selected index when original posts change
   useEffect(() => {
     setSelectedPostIndex(0);
   }, [posts]);
 
+  useEffect(() => {
+    let animationFrame = 0;
+
+    const selectNearestPost = () => {
+      animationFrame = 0;
+      const section = sectionRef.current;
+      const sectionBounds = section?.getBoundingClientRect();
+      const readingLine = window.innerHeight * 0.45;
+      const sectionIsVisible = Boolean(
+        sectionBounds &&
+          sectionBounds.top <= readingLine &&
+          sectionBounds.bottom > readingLine
+      );
+
+      setIsWritingVisible((current) =>
+        current === sectionIsVisible ? current : sectionIsVisible
+      );
+
+      const anchor = window.innerHeight * 0.36;
+      let nearestIndex = 0;
+      let nearestDistance = Number.POSITIVE_INFINITY;
+
+      postRefs.current.forEach((post, index) => {
+        if (!post) return;
+        const bounds = post.getBoundingClientRect();
+        const distance = Math.abs(bounds.top + bounds.height / 2 - anchor);
+
+        if (distance < nearestDistance) {
+          nearestDistance = distance;
+          nearestIndex = index;
+        }
+      });
+
+      setSelectedPostIndex((current) =>
+        current === nearestIndex ? current : nearestIndex
+      );
+    };
+
+    const scheduleSelection = () => {
+      if (animationFrame) return;
+      animationFrame = window.requestAnimationFrame(selectNearestPost);
+    };
+
+    selectNearestPost();
+    window.addEventListener("scroll", scheduleSelection, { passive: true });
+    window.addEventListener("resize", scheduleSelection);
+
+    return () => {
+      window.removeEventListener("scroll", scheduleSelection);
+      window.removeEventListener("resize", scheduleSelection);
+      if (animationFrame) window.cancelAnimationFrame(animationFrame);
+    };
+  }, [sortedPosts]);
+
   if (!sortedPosts.length) return null;
 
+  const selectedPost = sortedPosts[selectedPostIndex] ?? sortedPosts[0];
+  const preloadBatchStart =
+    selectedPostIndex === 0
+      ? 1
+      : Math.floor(selectedPostIndex / 3) * 3 + 1;
+  const preloadBatch = sortedPosts.slice(
+    preloadBatchStart,
+    preloadBatchStart + 3
+  );
+  const deckPosts = sortedPosts
+    .map((post, index) => ({ post, index }))
+    .slice(
+      Math.max(0, selectedPostIndex - 1),
+      Math.min(sortedPosts.length, selectedPostIndex + 3)
+    );
+
   return (
-    <div className="w-full flex flex-col group">
-      <PostTable
-        posts={sortedPosts}
-        selectedPostIndex={selectedPostIndex}
-        onSelectPost={setSelectedPostIndex}
-      />
-      <PostStack
-        posts={sortedPosts}
-        selectedPostIndex={selectedPostIndex}
-        onSelectPost={setSelectedPostIndex}
-      />
-    </div>
+    <section
+      ref={sectionRef}
+      aria-labelledby="posts-heading"
+      className="relative w-full"
+    >
+      <div className="sticky top-0 z-20 -mx-2 flex items-baseline justify-between gap-4 bg-background/90 px-2 py-4 backdrop-blur-sm">
+        <h2
+          id="posts-heading"
+          className="font-serif text-3xl tracking-[-0.035em] text-foreground"
+        >
+          Writing
+        </h2>
+        <p className="text-sm tabular-nums text-muted/70">
+          {String(selectedPostIndex + 1).padStart(2, "0")} /{" "}
+          {String(sortedPosts.length).padStart(2, "0")}
+        </p>
+      </div>
+
+      <ol className="relative px-1 pb-[calc(14rem+25vh)] before:absolute before:bottom-0 before:left-[0.72rem] before:top-0 before:w-px before:bg-border before:content-[''] sm:px-3 sm:before:left-[1.22rem]">
+        {sortedPosts.map((post, index) => {
+          const isSelected = index === selectedPostIndex;
+
+          return (
+            <li
+              key={`${post.slug}-${index}`}
+              ref={(node) => {
+                postRefs.current[index] = node;
+              }}
+              className="relative grid min-h-20 grid-cols-[1.5rem_1fr] items-center gap-3 sm:grid-cols-[1.75rem_1fr] sm:gap-4"
+              data-post-index={index}
+            >
+              <span
+                aria-hidden="true"
+                className={`relative z-10 mx-auto size-2 rounded-full border transition-[background-color,border-color,transform] duration-150 ease-out motion-reduce:transition-none ${
+                  isSelected
+                    ? "scale-125 border-accent bg-accent"
+                    : "border-border bg-background"
+                }`}
+              />
+              <Link
+                aria-current={isSelected ? "true" : undefined}
+                className={`flex min-h-11 items-center py-4 text-[1.05rem] leading-snug tracking-[-0.015em] transition-colors duration-150 motion-reduce:transition-none ${
+                  isSelected
+                    ? "font-bold text-foreground"
+                    : "font-normal text-muted/65 hover:text-foreground"
+                }`}
+                href={getPostHref(post)}
+                onFocus={() => setSelectedPostIndex(index)}
+                rel={post.slug ? undefined : "noopener noreferrer"}
+                target={post.slug ? undefined : "_blank"}
+              >
+                {post.title}
+              </Link>
+            </li>
+          );
+        })}
+      </ol>
+
+      <div
+        data-writing-deck
+        className={`fixed inset-x-4 bottom-[env(safe-area-inset-bottom)] z-30 mx-auto h-[clamp(10rem,38vw,14rem)] max-w-xl overflow-hidden transition-[transform,opacity] duration-200 [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
+          isWritingVisible
+            ? "translate-y-0 opacity-100"
+            : "pointer-events-none translate-y-8 opacity-0"
+        }`}
+      >
+        <div className="pointer-events-none absolute inset-0 overflow-hidden opacity-0">
+          {preloadBatch.map((post) =>
+            post.image ? (
+              <Image
+                key={`preload-${post.slug}`}
+                alt=""
+                className="object-cover"
+                data-preloaded-post={post.slug}
+                fill
+                loading="eager"
+                sizes={IMAGE_SIZES}
+                src={post.image}
+                unoptimized
+              />
+            ) : null
+          )}
+        </div>
+
+        <div className="relative h-[150%] w-full">
+          {deckPosts.map(({ post, index }) => {
+            const offset = index - selectedPostIndex;
+            const isSelected = offset === 0;
+            const translateY = offset < 0 ? -32 : offset * 12;
+            const scale = offset < 0 ? 1.015 : 1 - offset * 0.025;
+            const opacity = offset < 0 ? 0 : 1 - offset * 0.14;
+
+            return (
+              <Link
+                key={`deck-${post.slug}`}
+                aria-hidden={isSelected ? undefined : true}
+                className={`absolute inset-0 overflow-hidden rounded-t-2xl border border-border bg-surface shadow-lg transition-[transform,opacity] duration-200 [transition-timing-function:cubic-bezier(0.77,0,0.175,1)] motion-reduce:transition-none ${
+                  isSelected
+                    ? "pointer-events-auto"
+                    : "pointer-events-none"
+                }`}
+                href={getPostHref(post)}
+                rel={post.slug ? undefined : "noopener noreferrer"}
+                style={{
+                  opacity,
+                  transform: `translateY(${translateY}px) scale(${scale})`,
+                  transformOrigin: "center top",
+                  zIndex: 40 - offset,
+                }}
+                tabIndex={isSelected ? undefined : -1}
+                target={post.slug ? undefined : "_blank"}
+              >
+                {post.image ? (
+                  <Image
+                    alt={post.title}
+                    className="object-cover"
+                    fill
+                    loading={isSelected ? "eager" : "lazy"}
+                    sizes={IMAGE_SIZES}
+                    src={post.image}
+                    unoptimized
+                  />
+                ) : (
+                  <span className="flex h-full items-center justify-center px-8 text-center font-serif text-2xl text-muted">
+                    {post.title}
+                  </span>
+                )}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </section>
   );
 }

--- a/components/posts/post-visualizer.tsx
+++ b/components/posts/post-visualizer.tsx
@@ -166,10 +166,10 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
 
       <div
         data-writing-deck
-        className={`fixed inset-x-4 bottom-[env(safe-area-inset-bottom)] z-30 mx-auto h-[clamp(10rem,38vw,14rem)] max-w-xl overflow-hidden transition-[transform,opacity] duration-200 [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
+        className={`fixed inset-x-4 bottom-[env(safe-area-inset-bottom)] z-30 mx-auto h-[clamp(10rem,38vw,14rem)] max-w-xl overflow-hidden will-change-transform transition-[transform,opacity] duration-[240ms] [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
           isWritingVisible
-            ? "translate-y-0 opacity-100"
-            : "pointer-events-none translate-y-8 opacity-0"
+            ? "[transform:translateY(0)] opacity-100"
+            : "pointer-events-none [transform:translateY(100%)] opacity-0"
         }`}
       >
         <div className="pointer-events-none absolute inset-0 overflow-hidden opacity-0">
@@ -194,7 +194,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
           {deckPosts.map(({ post, index }) => {
             const offset = index - selectedPostIndex;
             const isSelected = offset === 0;
-            const translateY = offset < 0 ? -32 : offset * 12;
+            const translateY = offset < 0 ? "-12%" : `${offset * 100}%`;
             const scale = offset < 0 ? 1.015 : 1 - offset * 0.025;
             const opacity = offset < 0 ? 0 : 1 - offset * 0.14;
 
@@ -202,7 +202,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
               <Link
                 key={`deck-${post.slug}`}
                 aria-hidden={isSelected ? undefined : true}
-                className={`absolute inset-0 overflow-hidden rounded-t-2xl border border-border bg-surface shadow-lg transition-[transform,opacity] duration-200 [transition-timing-function:cubic-bezier(0.77,0,0.175,1)] motion-reduce:transition-none ${
+                className={`absolute inset-0 overflow-hidden rounded-t-2xl border border-border bg-surface shadow-lg will-change-transform transition-[transform,opacity] duration-[240ms] [transition-timing-function:cubic-bezier(0.77,0,0.175,1)] motion-reduce:transition-none ${
                   isSelected
                     ? "pointer-events-auto"
                     : "pointer-events-none"
@@ -211,7 +211,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                 rel={post.slug ? undefined : "noopener noreferrer"}
                 style={{
                   opacity,
-                  transform: `translateY(${translateY}px) scale(${scale})`,
+                  transform: `translateY(${translateY}) scale(${scale})`,
                   transformOrigin: "center top",
                   zIndex: 40 - offset,
                 }}

--- a/components/posts/post-visualizer.tsx
+++ b/components/posts/post-visualizer.tsx
@@ -6,6 +6,7 @@ import {
   type MouseEvent,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
 } from "react";
@@ -16,6 +17,46 @@ interface PostsVisualizerProps {
 }
 
 const IMAGE_SIZES = "(max-width: 768px) 92vw, 700px";
+
+type SelectionDirection = "forward" | "backward" | null;
+
+interface SelectionState {
+  currentIndex: number;
+  previousIndex: number | null;
+  direction: SelectionDirection;
+  transitionId: number;
+}
+
+type SelectionAction =
+  | { type: "reset" }
+  | { type: "select"; index: number; animate?: boolean };
+
+const initialSelection: SelectionState = {
+  currentIndex: 0,
+  previousIndex: null,
+  direction: null,
+  transitionId: 0,
+};
+
+function selectionReducer(
+  state: SelectionState,
+  action: SelectionAction
+): SelectionState {
+  if (action.type === "reset") return initialSelection;
+  if (action.index === state.currentIndex) return state;
+
+  return {
+    currentIndex: action.index,
+    previousIndex: action.animate === false ? null : state.currentIndex,
+    direction:
+      action.animate === false
+        ? null
+        : action.index > state.currentIndex
+          ? "forward"
+          : "backward",
+    transitionId: state.transitionId + 1,
+  };
+}
 
 function getPostHref(post: SubstackPost): string {
   return post.slug ? `/posts/${post.slug}` : post.link;
@@ -31,7 +72,10 @@ function formatPostDate(pubDate: string): string {
 }
 
 export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
-  const [selectedPostIndex, setSelectedPostIndex] = useState(0);
+  const [selection, dispatchSelection] = useReducer(
+    selectionReducer,
+    initialSelection
+  );
   const [isWritingVisible, setIsWritingVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
   const postRefs = useRef<Array<HTMLLIElement | null>>([]);
@@ -45,7 +89,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
   );
 
   useEffect(() => {
-    setSelectedPostIndex(0);
+    dispatchSelection({ type: "reset" });
   }, [posts]);
 
   useEffect(() => {
@@ -81,9 +125,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
         }
       });
 
-      setSelectedPostIndex((current) =>
-        current === nearestIndex ? current : nearestIndex
-      );
+      dispatchSelection({ type: "select", index: nearestIndex });
     };
 
     const scheduleSelection = () => {
@@ -104,7 +146,12 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
 
   if (!sortedPosts.length) return null;
 
+  const selectedPostIndex = selection.currentIndex;
   const selectedPost = sortedPosts[selectedPostIndex] ?? sortedPosts[0];
+  const previousPost =
+    selection.previousIndex === null
+      ? null
+      : sortedPosts[selection.previousIndex];
   const preloadBatchStart =
     selectedPostIndex === 0
       ? 1
@@ -181,7 +228,13 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                     : "font-normal text-muted/65 hover:text-foreground"
                 }`}
                 href={getPostHref(post)}
-                onFocus={() => setSelectedPostIndex(index)}
+                onFocus={() =>
+                  dispatchSelection({
+                    type: "select",
+                    index,
+                    animate: false,
+                  })
+                }
                 rel={post.slug ? undefined : "noopener noreferrer"}
                 target={post.slug ? undefined : "_blank"}
               >
@@ -234,9 +287,46 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
         </div>
 
         <div className="relative h-[150%] w-full">
+          {previousPost ? (
+            <Link
+              key={`previous-${previousPost.slug}-${selection.transitionId}`}
+              aria-hidden="true"
+              className={`pointer-events-none absolute inset-0 overflow-hidden rounded-t-2xl border border-border bg-surface shadow-lg ${
+                selection.direction === "forward"
+                  ? "artwork-stack-under z-10"
+                  : "artwork-destack-out z-20"
+              }`}
+              href={getPostHref(previousPost)}
+              rel={previousPost.slug ? undefined : "noopener noreferrer"}
+              tabIndex={-1}
+              target={previousPost.slug ? undefined : "_blank"}
+            >
+              {previousPost.image ? (
+                <Image
+                  alt=""
+                  className="object-cover"
+                  fill
+                  sizes={IMAGE_SIZES}
+                  src={previousPost.image}
+                  unoptimized
+                />
+              ) : (
+                <span className="flex h-full items-center justify-center px-8 text-center font-serif text-2xl text-muted">
+                  {previousPost.title}
+                </span>
+              )}
+            </Link>
+          ) : null}
+
           <Link
-            key={`deck-${selectedPost.slug}`}
-            className="absolute inset-0 overflow-hidden rounded-t-2xl border border-border bg-surface shadow-lg"
+            key={`deck-${selectedPost.slug}-${selection.transitionId}`}
+            className={`absolute inset-0 overflow-hidden rounded-t-2xl border border-border bg-surface shadow-lg ${
+              selection.direction === "forward"
+                ? "artwork-stack-in z-20"
+                : selection.direction === "backward"
+                  ? "artwork-destack-reveal z-10"
+                  : "z-10"
+            }`}
             href={getPostHref(selectedPost)}
             rel={selectedPost.slug ? undefined : "noopener noreferrer"}
             target={selectedPost.slug ? undefined : "_blank"}

--- a/components/posts/post-visualizer.tsx
+++ b/components/posts/post-visualizer.tsx
@@ -18,6 +18,34 @@ interface PostsVisualizerProps {
 
 const IMAGE_SIZES = "(max-width: 768px) 92vw, 700px";
 
+interface TimelineMilestone {
+  date: string;
+  id: string;
+  label: string;
+  text: string;
+}
+
+const TIMELINE_MILESTONES: TimelineMilestone[] = [
+  {
+    date: "2026-02-01T00:00:00.000Z",
+    id: "first-developer-role",
+    label: "February 2026",
+    text: "Started my first developer role at a large technology company.",
+  },
+  {
+    date: "2025-07-01T00:00:00.000Z",
+    id: "became-a-father",
+    label: "July 2025",
+    text: "Became a father.",
+  },
+  {
+    date: "2024-09-01T00:00:00.000Z",
+    id: "founded-deltalytix",
+    label: "September 2024",
+    text: "Founded Deltalytix, which I still operate today.",
+  },
+];
+
 type SelectionDirection = "forward" | "backward" | null;
 
 interface SelectionState {
@@ -86,6 +114,25 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
         (a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime()
       ),
     [posts]
+  );
+  const timelineEntries = useMemo(
+    () =>
+      [
+        ...sortedPosts.map((post, postIndex) => ({
+          date: post.pubDate,
+          kind: "post" as const,
+          post,
+          postIndex,
+        })),
+        ...TIMELINE_MILESTONES.map((milestone) => ({
+          date: milestone.date,
+          kind: "milestone" as const,
+          milestone,
+        })),
+      ].sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+      ),
+    [sortedPosts]
   );
 
   useEffect(() => {
@@ -200,17 +247,51 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
       </div>
 
       <ol className="relative px-1 pb-[calc(14rem+25vh)] before:absolute before:bottom-0 before:left-4 before:top-0 before:w-px before:bg-border before:content-[''] sm:px-3 sm:before:left-[1.625rem]">
-        {sortedPosts.map((post, index) => {
-          const isSelected = index === selectedPostIndex;
+        {timelineEntries.map((entry) => {
+          if (entry.kind === "milestone") {
+            const { milestone } = entry;
+
+            return (
+              <li
+                key={milestone.id}
+                className="relative grid min-h-28 grid-cols-[1.5rem_1fr] items-center gap-3 sm:grid-cols-[1.75rem_1fr] sm:gap-4"
+                data-timeline-highlight={milestone.id}
+              >
+                <span
+                  aria-hidden="true"
+                  className="relative z-10 mx-auto size-3 rounded-full border-2 border-background bg-accent shadow-[0_0_0_1px_var(--accent)]"
+                />
+                <div className="my-4 rounded-xl border border-accent/20 bg-accent/[0.07] px-4 py-3.5">
+                  <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+                    <span className="text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-accent">
+                      Highlight
+                    </span>
+                    <time
+                      className="text-xs font-medium tabular-nums text-muted/60"
+                      dateTime={milestone.date}
+                    >
+                      {milestone.label}
+                    </time>
+                  </div>
+                  <p className="mt-1.5 font-serif text-lg leading-snug tracking-[-0.015em] text-foreground">
+                    {milestone.text}
+                  </p>
+                </div>
+              </li>
+            );
+          }
+
+          const { post, postIndex } = entry;
+          const isSelected = postIndex === selectedPostIndex;
 
           return (
             <li
-              key={`${post.slug}-${index}`}
+              key={`${post.slug}-${postIndex}`}
               ref={(node) => {
-                postRefs.current[index] = node;
+                postRefs.current[postIndex] = node;
               }}
               className="relative grid min-h-20 grid-cols-[1.5rem_1fr] items-center gap-3 sm:grid-cols-[1.75rem_1fr] sm:gap-4"
-              data-post-index={index}
+              data-post-index={postIndex}
             >
               <span
                 aria-hidden="true"
@@ -231,7 +312,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                 onFocus={() =>
                   dispatchSelection({
                     type: "select",
-                    index,
+                    index: postIndex,
                     animate: false,
                   })
                 }

--- a/components/posts/post-visualizer.tsx
+++ b/components/posts/post-visualizer.tsx
@@ -157,7 +157,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
         </p>
       </div>
 
-      <ol className="relative px-1 pb-[calc(14rem+25vh)] before:absolute before:bottom-0 before:left-[0.72rem] before:top-0 before:w-px before:bg-border before:content-[''] sm:px-3 sm:before:left-[1.22rem]">
+      <ol className="relative px-1 pb-[calc(14rem+25vh)] before:absolute before:bottom-0 before:left-4 before:top-0 before:w-px before:bg-border before:content-[''] sm:px-3 sm:before:left-[1.625rem]">
         {sortedPosts.map((post, index) => {
           const isSelected = index === selectedPostIndex;
 

--- a/components/posts/post-visualizer.tsx
+++ b/components/posts/post-visualizer.tsx
@@ -2,7 +2,13 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  type MouseEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { SubstackPost } from "@/types/substack-post";
 
 interface PostsVisualizerProps {
@@ -13,6 +19,15 @@ const IMAGE_SIZES = "(max-width: 768px) 92vw, 700px";
 
 function getPostHref(post: SubstackPost): string {
   return post.slug ? `/posts/${post.slug}` : post.link;
+}
+
+function formatPostDate(pubDate: string): string {
+  return new Intl.DateTimeFormat("en", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(new Date(pubDate));
 }
 
 export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
@@ -105,6 +120,17 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
       Math.min(sortedPosts.length, selectedPostIndex + 3)
     );
 
+  const returnToWritingStart = (event: MouseEvent<HTMLButtonElement>) => {
+    const shouldReduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+
+    sectionRef.current?.scrollIntoView({
+      behavior: shouldReduceMotion || event.detail === 0 ? "auto" : "smooth",
+      block: "start",
+    });
+  };
+
   return (
     <section
       ref={sectionRef}
@@ -116,7 +142,14 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
           id="posts-heading"
           className="font-serif text-3xl tracking-[-0.035em] text-foreground"
         >
-          Writing
+          <button
+            aria-label="Return to the beginning of Writing"
+            className="-mx-2 min-h-11 cursor-pointer px-2 text-left transition-transform duration-150 active:scale-[0.98] motion-reduce:transition-none"
+            onClick={returnToWritingStart}
+            type="button"
+          >
+            Writing
+          </button>
         </h2>
         <p className="text-sm tabular-nums text-muted/70">
           {String(selectedPostIndex + 1).padStart(2, "0")} /{" "}
@@ -157,7 +190,16 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                 rel={post.slug ? undefined : "noopener noreferrer"}
                 target={post.slug ? undefined : "_blank"}
               >
-                {post.title}
+                <span>
+                  {post.title}
+                  <span
+                    className={`ml-2 whitespace-nowrap text-sm font-normal tracking-normal ${
+                      isSelected ? "text-muted/70" : "text-muted/45"
+                    }`}
+                  >
+                    • {formatPostDate(post.pubDate)}
+                  </span>
+                </span>
               </Link>
             </li>
           );
@@ -194,8 +236,8 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
           {deckPosts.map(({ post, index }) => {
             const offset = index - selectedPostIndex;
             const isSelected = offset === 0;
-            const translateY = offset < 0 ? "-12%" : `${offset * 100}%`;
-            const scale = offset < 0 ? 1.015 : 1 - offset * 0.025;
+            const translateY = offset < 0 ? "100%" : `${offset * 100}%`;
+            const scale = offset < 0 ? 0.975 : 1 - offset * 0.025;
             const opacity = offset < 0 ? 0 : 1 - offset * 0.14;
 
             return (

--- a/components/posts/post-visualizer.tsx
+++ b/components/posts/post-visualizer.tsx
@@ -113,12 +113,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
     preloadBatchStart,
     preloadBatchStart + 3
   );
-  const deckPosts = sortedPosts
-    .map((post, index) => ({ post, index }))
-    .slice(
-      Math.max(0, selectedPostIndex - 1),
-      Math.min(sortedPosts.length, selectedPostIndex + 3)
-    );
+  const isFirstArtwork = selectedPostIndex === 0;
 
   const returnToWritingStart = (event: MouseEvent<HTMLButtonElement>) => {
     const shouldReduceMotion = window.matchMedia(
@@ -208,10 +203,16 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
 
       <div
         data-writing-deck
-        className={`fixed inset-x-4 bottom-[env(safe-area-inset-bottom)] z-30 mx-auto h-[clamp(10rem,38vw,14rem)] max-w-xl overflow-hidden will-change-transform transition-[transform,opacity] duration-[240ms] [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
+        className={`fixed inset-x-4 bottom-[env(safe-area-inset-bottom)] z-30 mx-auto h-[clamp(10rem,38vw,14rem)] max-w-xl overflow-hidden motion-reduce:transition-none ${
+          isFirstArtwork
+            ? "will-change-transform transition-[transform,opacity] duration-[240ms] [transition-timing-function:cubic-bezier(0.23,1,0.32,1)]"
+            : "transition-none"
+        } ${
           isWritingVisible
             ? "[transform:translateY(0)] opacity-100"
-            : "pointer-events-none [transform:translateY(100%)] opacity-0"
+            : isFirstArtwork
+              ? "pointer-events-none [transform:translateY(100%)] opacity-0"
+              : "pointer-events-none [transform:translateY(0)] opacity-0"
         }`}
       >
         <div className="pointer-events-none absolute inset-0 overflow-hidden opacity-0">
@@ -233,51 +234,29 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
         </div>
 
         <div className="relative h-[150%] w-full">
-          {deckPosts.map(({ post, index }) => {
-            const offset = index - selectedPostIndex;
-            const isSelected = offset === 0;
-            const translateY = offset < 0 ? "100%" : `${offset * 100}%`;
-            const scale = offset < 0 ? 0.975 : 1 - offset * 0.025;
-            const opacity = offset < 0 ? 0 : 1 - offset * 0.14;
-
-            return (
-              <Link
-                key={`deck-${post.slug}`}
-                aria-hidden={isSelected ? undefined : true}
-                className={`absolute inset-0 overflow-hidden rounded-t-2xl border border-border bg-surface shadow-lg will-change-transform transition-[transform,opacity] duration-[240ms] [transition-timing-function:cubic-bezier(0.77,0,0.175,1)] motion-reduce:transition-none ${
-                  isSelected
-                    ? "pointer-events-auto"
-                    : "pointer-events-none"
-                }`}
-                href={getPostHref(post)}
-                rel={post.slug ? undefined : "noopener noreferrer"}
-                style={{
-                  opacity,
-                  transform: `translateY(${translateY}) scale(${scale})`,
-                  transformOrigin: "center top",
-                  zIndex: 40 - offset,
-                }}
-                tabIndex={isSelected ? undefined : -1}
-                target={post.slug ? undefined : "_blank"}
-              >
-                {post.image ? (
-                  <Image
-                    alt={post.title}
-                    className="object-cover"
-                    fill
-                    loading={isSelected ? "eager" : "lazy"}
-                    sizes={IMAGE_SIZES}
-                    src={post.image}
-                    unoptimized
-                  />
-                ) : (
-                  <span className="flex h-full items-center justify-center px-8 text-center font-serif text-2xl text-muted">
-                    {post.title}
-                  </span>
-                )}
-              </Link>
-            );
-          })}
+          <Link
+            key={`deck-${selectedPost.slug}`}
+            className="absolute inset-0 overflow-hidden rounded-t-2xl border border-border bg-surface shadow-lg"
+            href={getPostHref(selectedPost)}
+            rel={selectedPost.slug ? undefined : "noopener noreferrer"}
+            target={selectedPost.slug ? undefined : "_blank"}
+          >
+            {selectedPost.image ? (
+              <Image
+                alt={selectedPost.title}
+                className="object-cover"
+                fill
+                loading="eager"
+                sizes={IMAGE_SIZES}
+                src={selectedPost.image}
+                unoptimized
+              />
+            ) : (
+              <span className="flex h-full items-center justify-center px-8 text-center font-serif text-2xl text-muted">
+                {selectedPost.title}
+              </span>
+            )}
+          </Link>
         </div>
       </div>
     </section>

--- a/components/posts/substack-posts.tsx
+++ b/components/posts/substack-posts.tsx
@@ -1,7 +1,6 @@
 import { fetchSubstackPosts } from "@/server/substack-feed";
 import SubstackVisualizer from "./post-visualizer";
 import { Suspense } from "react";
-import "./post.css";
 
 export default function SubstackPosts() {
   return (

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,6 +1,5 @@
 import { getSpotifyData } from "@/server/spotify";
 import Image from "next/image";
-import Link from "next/link";
 
 export async function SiteFooter() {
   const data = await getSpotifyData();
@@ -71,33 +70,6 @@ export async function SiteFooter() {
         </div>
       </div>
 
-      <div className="max-w-4xl mx-auto px-4 sm:px-8 py-3">
-        <p className="text-xs text-muted mb-2">Socials</p>
-        <div className="flex items-center gap-3">
-          <Link
-            href="https://x.com/hugodemenez"
-            rel="noopener noreferrer"
-            className="text-sm text-muted font-bold hover:text-accent transition-colors flex items-center gap-2 group"
-          >
-            <svg width="16" height="16" viewBox="0 0 1200 1227" xmlns="http://www.w3.org/2000/svg">
-              <path className="fill-foreground group-hover:fill-accent transition-colors" d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z" />
-            </svg>
-            @hugodemenez
-          </Link>
-          <Link
-            href="https://github.com/hugodemenez"
-            rel="noopener noreferrer"
-            className="flex gap-2 group text-sm text-muted hover:text-accent transition-colors items-center font-bold"
-          >
-            <svg width="24" height="24" viewBox="0 0 98 96" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <g clipPath="url(#clip0_730_27126)">
-                <path className="fill-foreground group-hover:fill-accent transition-colors" d="M41.4395 69.3848C28.8066 67.8535 19.9062 58.7617 19.9062 46.9902C19.9062 42.2051 21.6289 37.0371 24.5 33.5918C23.2559 30.4336 23.4473 23.7344 24.8828 20.959C28.7109 20.4805 33.8789 22.4902 36.9414 25.2656C40.5781 24.1172 44.4062 23.543 49.0957 23.543C53.7852 23.543 57.6133 24.1172 61.0586 25.1699C64.0254 22.4902 69.2891 20.4805 73.1172 20.959C74.457 23.543 74.6484 30.2422 73.4043 33.4961C76.4668 37.1328 78.0937 42.0137 78.0937 46.9902C78.0937 58.7617 69.1934 67.6621 56.3691 69.2891C59.623 71.3945 61.8242 75.9883 61.8242 81.252L61.8242 91.2051C61.8242 94.0762 64.2168 95.7031 67.0879 94.5547C84.4102 87.9512 98 70.6289 98 49.1914C98 22.1074 75.9883 6.69539e-07 48.9043 4.309e-07C21.8203 1.92261e-07 -1.9479e-07 22.1074 -4.3343e-07 49.1914C-6.20631e-07 70.4375 13.4941 88.0469 31.6777 94.6504C34.2617 95.6074 36.75 93.8848 36.75 91.3008L36.75 83.6445C35.4102 84.2188 33.6875 84.6016 32.1562 84.6016C25.8398 84.6016 22.1074 81.1563 19.4277 74.7441C18.375 72.1602 17.2266 70.6289 15.0254 70.3418C13.877 70.2461 13.4941 69.7676 13.4941 69.1934C13.4941 68.0449 15.4082 67.1836 17.3223 67.1836C20.0977 67.1836 22.4902 68.9063 24.9785 72.4473C26.8926 75.2227 28.9023 76.4668 31.2949 76.4668C33.6875 76.4668 35.2187 75.6055 37.4199 73.4043C39.0469 71.7773 40.291 70.3418 41.4395 69.3848Z" />
-              </g>
-            </svg>
-            hugodemenez
-          </Link>
-        </div>
-      </div>
     </footer>
   );
 }

--- a/components/weather-pill.tsx
+++ b/components/weather-pill.tsx
@@ -24,8 +24,26 @@ function InfoIcon() {
 
 export default function WeatherPill({ weather }: WeatherPillProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [localTime, setLocalTime] = useState(weather?.time ?? "local time");
   const rootRef = useRef<HTMLSpanElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const updateLocalTime = () => {
+      setLocalTime(
+        new Intl.DateTimeFormat("en-US", {
+          hour: "numeric",
+          minute: "2-digit",
+          timeZone: "Europe/Lisbon",
+        }).format(new Date())
+      );
+    };
+
+    updateLocalTime();
+    const interval = window.setInterval(updateLocalTime, 30_000);
+
+    return () => window.clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -89,20 +107,19 @@ export default function WeatherPill({ weather }: WeatherPillProps) {
         id="weather-details"
         aria-label="Lisbon weather details"
         aria-hidden={!isOpen}
-        className={`absolute right-0 top-[calc(100%+0.5rem)] z-40 w-56 origin-top-right rounded-xl border border-border bg-background px-3.5 py-3 text-left text-xs leading-relaxed text-muted shadow-lg transition-[opacity,transform] duration-150 [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
+        className={`absolute right-0 top-[calc(100%+0.5rem)] z-40 w-64 max-w-[calc(100vw-2rem)] origin-top-right rounded-xl border border-border bg-background px-3.5 py-3 text-left text-xs leading-relaxed text-muted shadow-lg transition-[opacity,transform] duration-150 [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
           isOpen
             ? "pointer-events-auto translate-y-0 scale-100 opacity-100"
             : "pointer-events-none -translate-y-1 scale-[0.97] opacity-0"
         }`}
         role="dialog"
       >
-        <span className="block font-medium text-foreground">
+        <span className="block text-foreground">
+          I am currently based in Lisbon. Here, it’s {localTime}
           {weather
-            ? `${weather.time} · ${weather.temperature}°C, ${weather.condition}`
-            : "Current weather is unavailable"}
-        </span>
-        <span className="mt-1 block text-muted/65">
-          Data by{" "}
+            ? `, and the weather is ${weather.condition.toLowerCase()} at ${weather.temperature}°C`
+            : ", though the current weather is unavailable"}
+          . The data comes from{" "}
           <a
             className="underline decoration-border underline-offset-2 transition-colors hover:text-foreground"
             href="https://open-meteo.com/"
@@ -112,6 +129,7 @@ export default function WeatherPill({ weather }: WeatherPillProps) {
           >
             Open-Meteo
           </a>
+          .
         </span>
       </span>
     </span>

--- a/components/weather-pill.tsx
+++ b/components/weather-pill.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { LocationWeather } from "@/server/location";
+
+interface WeatherPillProps {
+  weather: LocationWeather | null;
+}
+
+function InfoIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-3.5"
+      fill="none"
+      viewBox="0 0 16 16"
+    >
+      <circle cx="8" cy="8" r="5.75" stroke="currentColor" strokeWidth="1.25" />
+      <path d="M8 7.1v3.3" stroke="currentColor" strokeLinecap="round" strokeWidth="1.25" />
+      <circle cx="8" cy="5.15" r=".7" fill="currentColor" />
+    </svg>
+  );
+}
+
+export default function WeatherPill({ weather }: WeatherPillProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const rootRef = useRef<HTMLSpanElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const closeOnOutsidePress = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setIsOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setIsOpen(false);
+      buttonRef.current?.focus();
+    };
+
+    document.addEventListener("pointerdown", closeOnOutsidePress);
+    document.addEventListener("keydown", closeOnEscape);
+
+    return () => {
+      document.removeEventListener("pointerdown", closeOnOutsidePress);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [isOpen]);
+
+  return (
+    <span
+      ref={rootRef}
+      className="relative inline-flex"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) setIsOpen(false);
+      }}
+    >
+      <span
+        aria-label="Current location and weather"
+        className="inline-flex h-8 items-center gap-1.5 rounded-full bg-surface py-1 pl-3 pr-1 text-xs tracking-[-0.01em] text-muted"
+      >
+        <span className="whitespace-nowrap">{weather?.location ?? "Lisbon"}</span>
+        {weather ? (
+          <>
+            <span aria-hidden="true" className="text-foreground/25">
+              •
+            </span>
+            <span className="whitespace-nowrap tabular-nums">
+              {weather.temperature}°C
+            </span>
+          </>
+        ) : null}
+        <button
+          ref={buttonRef}
+          aria-controls="weather-details"
+          aria-expanded={isOpen}
+          aria-haspopup="dialog"
+          aria-label="About the Lisbon weather"
+          className="relative grid size-6 shrink-0 place-items-center rounded-full text-muted/55 transition-[background-color,color,transform] duration-150 hover:bg-background/70 hover:text-foreground active:scale-[0.94] motion-reduce:transition-none after:absolute after:-inset-2 after:content-['']"
+          onClick={() => setIsOpen((open) => !open)}
+          type="button"
+        >
+          <InfoIcon />
+        </button>
+      </span>
+
+      <span
+        id="weather-details"
+        aria-label="Lisbon weather details"
+        aria-hidden={!isOpen}
+        className={`absolute right-0 top-[calc(100%+0.5rem)] z-40 w-56 origin-top-right rounded-xl border border-border bg-background px-3.5 py-3 text-left text-xs leading-relaxed text-muted shadow-lg transition-[opacity,transform] duration-150 [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
+          isOpen
+            ? "pointer-events-auto translate-y-0 scale-100 opacity-100"
+            : "pointer-events-none -translate-y-1 scale-[0.97] opacity-0"
+        }`}
+        role="dialog"
+      >
+        <span className="block font-medium text-foreground">
+          {weather
+            ? `${weather.time} · ${weather.temperature}°C, ${weather.condition}`
+            : "Current weather is unavailable"}
+        </span>
+        <span className="mt-1 block text-muted/65">
+          Data by{" "}
+          <a
+            className="underline decoration-border underline-offset-2 transition-colors hover:text-foreground"
+            href="https://open-meteo.com/"
+            rel="noreferrer"
+            tabIndex={isOpen ? 0 : -1}
+            target="_blank"
+          >
+            Open-Meteo
+          </a>
+        </span>
+      </span>
+    </span>
+  );
+}

--- a/components/weather-pill.tsx
+++ b/components/weather-pill.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { LocationWeather } from "@/server/location";
+import { formatLocalTime, isLocationStale } from "@/lib/location-display";
 
 interface WeatherPillProps {
   weather: LocationWeather | null;
@@ -24,26 +25,36 @@ function InfoIcon() {
 
 export default function WeatherPill({ weather }: WeatherPillProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [localTime, setLocalTime] = useState(weather?.time ?? "local time");
+  const [localTime, setLocalTime] = useState<string | null>(null);
+  const [isStale, setIsStale] = useState(false);
   const rootRef = useRef<HTMLSpanElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const updateLocalTime = () => {
-      setLocalTime(
-        new Intl.DateTimeFormat("en-US", {
-          hour: "numeric",
-          minute: "2-digit",
-          timeZone: "Europe/Lisbon",
-        }).format(new Date())
-      );
+      setLocalTime(formatLocalTime(weather?.timeZone ?? null));
     };
 
     updateLocalTime();
     const interval = window.setInterval(updateLocalTime, 30_000);
 
     return () => window.clearInterval(interval);
-  }, []);
+  }, [weather?.timeZone]);
+
+  useEffect(() => {
+    setIsStale(isLocationStale(weather?.updatedAt ?? null, new Date()));
+  }, [weather?.updatedAt]);
+
+  const updatedDate = weather?.updatedAt
+    ? new Intl.DateTimeFormat("en-US", {
+        month: "long",
+        day: "numeric",
+      }).format(Date.parse(weather.updatedAt))
+    : null;
+  const weatherDescription =
+    weather?.condition && weather.temperature !== null
+      ? `${weather.condition.toLowerCase()} at ${weather.temperature}°C`
+      : null;
 
   useEffect(() => {
     if (!isOpen) return;
@@ -79,13 +90,13 @@ export default function WeatherPill({ weather }: WeatherPillProps) {
         className="inline-flex h-6 items-center gap-1 rounded-full bg-surface pl-2.5 pr-0.5 text-[0.625rem] tracking-[-0.01em] text-muted"
       >
         <span className="whitespace-nowrap">{weather?.location ?? "Lisbon"}</span>
-        {weather ? (
+        {weather?.temperature !== null ? (
           <>
             <span aria-hidden="true" className="text-foreground/25">
               •
             </span>
             <span className="whitespace-nowrap tabular-nums">
-              {weather.temperature}°C
+              {weather?.temperature}°C
             </span>
           </>
         ) : null}
@@ -94,7 +105,7 @@ export default function WeatherPill({ weather }: WeatherPillProps) {
           aria-controls="weather-details"
           aria-expanded={isOpen}
           aria-haspopup="dialog"
-          aria-label="About the Lisbon weather"
+          aria-label={`About the weather in ${weather?.location ?? "Lisbon"}`}
           className="relative grid size-5 shrink-0 place-items-center rounded-full text-muted/55 transition-[background-color,color,transform] duration-150 hover:bg-background/70 hover:text-foreground active:scale-[0.94] motion-reduce:transition-none after:absolute after:-inset-3 after:content-['']"
           onClick={() => setIsOpen((open) => !open)}
           type="button"
@@ -105,7 +116,7 @@ export default function WeatherPill({ weather }: WeatherPillProps) {
 
       <span
         id="weather-details"
-        aria-label="Lisbon weather details"
+        aria-label={`${weather?.location ?? "Lisbon"} weather details`}
         aria-hidden={!isOpen}
         className={`absolute right-0 top-[calc(100%+0.5rem)] z-40 w-64 max-w-[calc(100vw-2rem)] origin-top-right rounded-xl border border-border bg-background px-3.5 py-3 text-left text-xs leading-relaxed text-muted shadow-lg transition-[opacity,transform] duration-150 [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
           isOpen
@@ -115,11 +126,17 @@ export default function WeatherPill({ weather }: WeatherPillProps) {
         role="dialog"
       >
         <span className="block text-foreground">
-          I am currently based in Lisbon. Here, it’s {localTime}
-          {weather
-            ? `, and the weather is ${weather.condition.toLowerCase()} at ${weather.temperature}°C`
-            : ", though the current weather is unavailable"}
-          . The data comes from{" "}
+          {weather?.isHomeBase
+            ? "My home base is Lisbon."
+            : isStale
+              ? `My last known location is ${weather?.location ?? "Lisbon"}, updated ${updatedDate}.`
+              : `I’m currently in ${weather?.location ?? "Lisbon"}.`}{" "}
+          {localTime && weatherDescription
+            ? `Here, it’s ${localTime}, and the weather is ${weatherDescription}.`
+            : localTime
+              ? `Here, it’s ${localTime}, though the current weather is unavailable.`
+              : "The current local time and weather are unavailable."}{" "}
+          Weather data comes from{" "}
           <a
             className="underline decoration-border underline-offset-2 transition-colors hover:text-foreground"
             href="https://open-meteo.com/"

--- a/components/weather-pill.tsx
+++ b/components/weather-pill.tsx
@@ -69,7 +69,7 @@ export default function WeatherPill({ weather }: WeatherPillProps) {
   return (
     <span
       ref={rootRef}
-      className="relative mb-1 inline-flex"
+      className="relative inline-flex"
       onBlur={(event) => {
         if (!event.currentTarget.contains(event.relatedTarget)) setIsOpen(false);
       }}

--- a/components/weather-pill.tsx
+++ b/components/weather-pill.tsx
@@ -11,7 +11,7 @@ function InfoIcon() {
   return (
     <svg
       aria-hidden="true"
-      className="size-3"
+      className="size-2.5"
       fill="none"
       viewBox="0 0 16 16"
     >
@@ -76,7 +76,7 @@ export default function WeatherPill({ weather }: WeatherPillProps) {
     >
       <span
         aria-label="Current location and weather"
-        className="inline-flex h-7 items-center gap-1.5 rounded-full bg-surface pl-2.5 pr-0.5 text-[0.6875rem] tracking-[-0.01em] text-muted"
+        className="inline-flex h-6 items-center gap-1 rounded-full bg-surface pl-2.5 pr-0.5 text-[0.625rem] tracking-[-0.01em] text-muted"
       >
         <span className="whitespace-nowrap">{weather?.location ?? "Lisbon"}</span>
         {weather ? (
@@ -95,7 +95,7 @@ export default function WeatherPill({ weather }: WeatherPillProps) {
           aria-expanded={isOpen}
           aria-haspopup="dialog"
           aria-label="About the Lisbon weather"
-          className="relative grid size-6 shrink-0 place-items-center rounded-full text-muted/55 transition-[background-color,color,transform] duration-150 hover:bg-background/70 hover:text-foreground active:scale-[0.94] motion-reduce:transition-none after:absolute after:-inset-2 after:content-['']"
+          className="relative grid size-5 shrink-0 place-items-center rounded-full text-muted/55 transition-[background-color,color,transform] duration-150 hover:bg-background/70 hover:text-foreground active:scale-[0.94] motion-reduce:transition-none after:absolute after:-inset-3 after:content-['']"
           onClick={() => setIsOpen((open) => !open)}
           type="button"
         >

--- a/components/weather-pill.tsx
+++ b/components/weather-pill.tsx
@@ -69,7 +69,7 @@ export default function WeatherPill({ weather }: WeatherPillProps) {
   return (
     <span
       ref={rootRef}
-      className="relative inline-flex"
+      className="relative mb-1 inline-flex"
       onBlur={(event) => {
         if (!event.currentTarget.contains(event.relatedTarget)) setIsOpen(false);
       }}

--- a/components/weather-pill.tsx
+++ b/components/weather-pill.tsx
@@ -11,7 +11,7 @@ function InfoIcon() {
   return (
     <svg
       aria-hidden="true"
-      className="size-3.5"
+      className="size-3"
       fill="none"
       viewBox="0 0 16 16"
     >
@@ -76,7 +76,7 @@ export default function WeatherPill({ weather }: WeatherPillProps) {
     >
       <span
         aria-label="Current location and weather"
-        className="inline-flex h-8 items-center gap-1.5 rounded-full bg-surface py-1 pl-3 pr-1 text-xs tracking-[-0.01em] text-muted"
+        className="inline-flex h-7 items-center gap-1.5 rounded-full bg-surface pl-2.5 pr-0.5 text-[0.6875rem] tracking-[-0.01em] text-muted"
       >
         <span className="whitespace-nowrap">{weather?.location ?? "Lisbon"}</span>
         {weather ? (

--- a/lib/location-display.test.ts
+++ b/lib/location-display.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatLocalTime, isLocationStale } from "./location-display";
+
+const now = new Date("2026-08-01T08:00:00.000Z");
+
+test("marks a location stale only after seven days", () => {
+  assert.equal(isLocationStale("2026-07-25T08:00:00.000Z", now), false);
+  assert.equal(isLocationStale("2026-07-25T07:59:59.999Z", now), true);
+  assert.equal(isLocationStale(null, now), false);
+});
+
+test("formats clocks in the weather service timezone", () => {
+  assert.equal(formatLocalTime("Europe/Lisbon", now), "9:00 AM");
+  assert.equal(formatLocalTime("America/New_York", now), "4:00 AM");
+  assert.equal(formatLocalTime("not/a-timezone", now), null);
+  assert.equal(formatLocalTime(null, now), null);
+});

--- a/lib/location-display.ts
+++ b/lib/location-display.ts
@@ -1,0 +1,26 @@
+const MAX_LOCATION_AGE_MS = 7 * 24 * 60 * 60 * 1_000;
+
+export function isLocationStale(
+  updatedAt: string | null,
+  now = new Date()
+): boolean {
+  if (!updatedAt) return false;
+  const timestamp = Date.parse(updatedAt);
+  return !Number.isFinite(timestamp) || now.getTime() - timestamp > MAX_LOCATION_AGE_MS;
+}
+
+export function formatLocalTime(
+  timeZone: string | null,
+  now = new Date()
+): string | null {
+  if (!timeZone) return null;
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone,
+    }).format(now);
+  } catch {
+    return null;
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'substackcdn.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'substack-post-media.s3.amazonaws.com',
+      },
     ],
     localPatterns: [
       {
@@ -17,7 +21,7 @@ const nextConfig: NextConfig = {
     ],
   },
   cacheComponents: true,
-  allowedDevOrigins: ['localhost', '192.168.1.25'],
+  allowedDevOrigins: ['localhost', '192.168.1.25', '192.168.0.140'],
   experimental: {
     mdxRs: true,
     viewTransition: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@next/mdx": "^16.0.0",
         "@tailwindcss/postcss": "^4.1.3",
-        "next": "^16.0.10",
+        "next": "^16.2.12",
         "next-mdx-remote": "^6.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1079,9 +1079,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.0.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.10.tgz",
-      "integrity": "sha512-8tuaQkyDVgeONQ1MeT9Mkk8pQmZapMKFh5B+OrFUlG3rVmYTXcXlBetBgTurKXGaIZvkoqRT9JL5K3phXcgang==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.12.tgz",
+      "integrity": "sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==",
       "license": "MIT"
     },
     "node_modules/@next/mdx": {
@@ -1106,9 +1106,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.10.tgz",
-      "integrity": "sha512-4XgdKtdVsaflErz+B5XeG0T5PeXKDdruDf3CRpnhN+8UebNa5N2H58+3GDgpn/9GBurrQ1uWW768FfscwYkJRg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.12.tgz",
+      "integrity": "sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==",
       "cpu": [
         "arm64"
       ],
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.10.tgz",
-      "integrity": "sha512-spbEObMvRKkQ3CkYVOME+ocPDFo5UqHb8EMTS78/0mQ+O1nqE8toHJVioZo4TvebATxgA8XMTHHrScPrn68OGw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.12.tgz",
+      "integrity": "sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==",
       "cpu": [
         "x64"
       ],
@@ -1138,9 +1138,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.10.tgz",
-      "integrity": "sha512-uQtWE3X0iGB8apTIskOMi2w/MKONrPOUCi5yLO+v3O8Mb5c7K4Q5KD1jvTpTF5gJKa3VH/ijKjKUq9O9UhwOYw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.12.tgz",
+      "integrity": "sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==",
       "cpu": [
         "arm64"
       ],
@@ -1154,9 +1154,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.10.tgz",
-      "integrity": "sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.12.tgz",
+      "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
       ],
@@ -1170,9 +1170,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.10.tgz",
-      "integrity": "sha512-AK2q5H0+a9nsXbeZ3FZdMtbtu9jxW4R/NgzZ6+lrTm3d6Zb7jYrWcgjcpM1k8uuqlSy4xIyPR2YiuUr+wXsavA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.12.tgz",
+      "integrity": "sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==",
       "cpu": [
         "x64"
       ],
@@ -1186,9 +1186,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.10.tgz",
-      "integrity": "sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.12.tgz",
+      "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
       ],
@@ -1202,9 +1202,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.10.tgz",
-      "integrity": "sha512-aEZIS4Hh32xdJQbHz121pyuVZniSNoqDVx1yIr2hy+ZwJGipeqnMZBJHyMxv2tiuAXGx6/xpTcQJ6btIiBjgmg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.12.tgz",
+      "integrity": "sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==",
       "cpu": [
         "arm64"
       ],
@@ -1218,9 +1218,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.10.tgz",
-      "integrity": "sha512-E+njfCoFLb01RAFEnGZn6ERoOqhK1Gl3Lfz1Kjnj0Ulfu7oJbuMyvBKNj/bw8XZnenHDASlygTjZICQW+rYW1Q==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.12.tgz",
+      "integrity": "sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==",
       "cpu": [
         "x64"
       ],
@@ -1231,15 +1231,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@swc/helpers": {
@@ -1602,15 +1593,6 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
-    "node_modules/@vercel/oidc": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz",
-      "integrity": "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1649,6 +1631,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.9",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.9.tgz",
+      "integrity": "sha512-cp447VUsGS07+n1Dqf7YSQ8maeJrjEhaDxTm1ZefbqDtypHBC5GzGMQbklR6IPR13Y8OAJRHZWEMtZipJLCttg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3248,13 +3242,14 @@
       }
     },
     "node_modules/next": {
-      "version": "16.0.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.0.10.tgz",
-      "integrity": "sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.12.tgz",
+      "integrity": "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.0.10",
+        "@next/env": "16.2.12",
         "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -3266,15 +3261,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.0.10",
-        "@next/swc-darwin-x64": "16.0.10",
-        "@next/swc-linux-arm64-gnu": "16.0.10",
-        "@next/swc-linux-arm64-musl": "16.0.10",
-        "@next/swc-linux-x64-gnu": "16.0.10",
-        "@next/swc-linux-x64-musl": "16.0.10",
-        "@next/swc-win32-arm64-msvc": "16.0.10",
-        "@next/swc-win32-x64-msvc": "16.0.10",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.12",
+        "@next/swc-darwin-x64": "16.2.12",
+        "@next/swc-linux-arm64-gnu": "16.2.12",
+        "@next/swc-linux-arm64-musl": "16.2.12",
+        "@next/swc-linux-x64-gnu": "16.2.12",
+        "@next/swc-linux-x64-musl": "16.2.12",
+        "@next/swc-win32-arm64-msvc": "16.2.12",
+        "@next/swc-win32-x64-msvc": "16.2.12",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@next/mdx": "^16.0.0",
         "@tailwindcss/postcss": "^4.1.3",
+        "@vercel/edge-config": "1.4.3",
         "next": "^16.2.12",
         "next-mdx-remote": "^6.0.0",
         "react": "^19.1.0",
@@ -1592,6 +1593,36 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/edge-config": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config/-/edge-config-1.4.3.tgz",
+      "integrity": "sha512-8vTDATodRrH49wMzKEjZ8/5H2qs1aPkD0uRK585f/Fx4YN2wfHfY/3td9OFrh+gdnCq07z8A5f0hoY6xhBcPkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/edge-config-fs": "0.1.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0",
+        "next": ">=1"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/edge-config-fs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz",
+      "integrity": "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==",
+      "license": "Apache-2.0"
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@next/mdx": "^16.0.0",
         "@tailwindcss/postcss": "^4.1.3",
-        "@vercel/edge-config": "1.4.3",
+        "@vercel/global-config": "1.5.0",
         "next": "^16.2.12",
         "next-mdx-remote": "^6.0.0",
         "react": "^19.1.0",
@@ -1594,10 +1594,16 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
-    "node_modules/@vercel/edge-config": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@vercel/edge-config/-/edge-config-1.4.3.tgz",
-      "integrity": "sha512-8vTDATodRrH49wMzKEjZ8/5H2qs1aPkD0uRK585f/Fx4YN2wfHfY/3td9OFrh+gdnCq07z8A5f0hoY6xhBcPkg==",
+    "node_modules/@vercel/edge-config-fs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz",
+      "integrity": "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/global-config": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/global-config/-/global-config-1.5.0.tgz",
+      "integrity": "sha512-YxyyzkIjlD7kHSlPpYOQun81Y1o3JUU19snytzFSex/l6h6t5kEg9UsWoG7F5BIT1aBcCmTGUtP5LpkeSN+b8w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/edge-config-fs": "0.1.0"
@@ -1617,12 +1623,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@vercel/edge-config-fs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz",
-      "integrity": "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==",
-      "license": "Apache-2.0"
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@next/mdx": "^16.0.0",
     "@tailwindcss/postcss": "^4.1.3",
-    "@vercel/edge-config": "1.4.3",
+    "@vercel/global-config": "1.5.0",
     "next": "^16.2.12",
     "next-mdx-remote": "^6.0.0",
     "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "sync-substack": "tsx scripts/sync-substack-posts.ts"
+    "sync-substack": "tsx scripts/sync-substack-posts.ts",
+    "test": "tsx --test server/location-data.test.ts server/location.test.ts lib/location-display.test.ts app/api/location/update/route.test.ts"
   },
   "dependencies": {
     "@next/mdx": "^16.0.0",
     "@tailwindcss/postcss": "^4.1.3",
+    "@vercel/edge-config": "1.4.3",
     "next": "^16.2.12",
     "next-mdx-remote": "^6.0.0",
     "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@next/mdx": "^16.0.0",
     "@tailwindcss/postcss": "^4.1.3",
-    "next": "^16.0.10",
+    "next": "^16.2.12",
     "next-mdx-remote": "^6.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/server/location-data.test.ts
+++ b/server/location-data.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createEdgeConfigWriteRequest,
+  hasValidBearerToken,
+  parseLocationUpdate,
+  parseStoredLocation,
+} from "./location-data";
+
+const now = new Date("2026-08-01T08:00:00.000Z");
+
+test("validates, normalizes, and rounds a location update", () => {
+  assert.deepEqual(
+    parseLocationUpdate(
+      {
+        city: "  New   York  ",
+        country: " United States ",
+        latitude: 40.7128,
+        longitude: -74.006,
+      },
+      now
+    ),
+    {
+      version: 1,
+      city: "New York",
+      country: "United States",
+      latitude: 40.71,
+      longitude: -74.01,
+      updatedAt: now.toISOString(),
+    }
+  );
+});
+
+test("rejects malformed locations and oversized names", () => {
+  assert.equal(parseLocationUpdate(null, now), null);
+  assert.equal(
+    parseLocationUpdate(
+      { city: "x".repeat(81), latitude: 1, longitude: 2 },
+      now
+    ),
+    null
+  );
+  assert.equal(
+    parseLocationUpdate({ city: "Lisbon", latitude: 91, longitude: 2 }, now),
+    null
+  );
+  assert.equal(
+    parseLocationUpdate({ city: "Lisbon", latitude: 1, longitude: -181 }, now),
+    null
+  );
+});
+
+test("rejects malformed stored records", () => {
+  assert.equal(parseStoredLocation({ version: 2 }), null);
+  assert.equal(
+    parseStoredLocation({
+      version: 1,
+      city: "Paris",
+      latitude: 48.86,
+      longitude: 2.35,
+      updatedAt: "not-a-date",
+    }),
+    null
+  );
+});
+
+test("checks bearer tokens and produces the authenticated batch upsert", () => {
+  assert.equal(hasValidBearerToken("Bearer shortcut-secret", "shortcut-secret"), true);
+  assert.equal(hasValidBearerToken("Bearer wrong", "shortcut-secret"), false);
+  assert.equal(hasValidBearerToken(null, "shortcut-secret"), false);
+
+  const location = parseLocationUpdate(
+    { city: "Paris", latitude: 48.8566, longitude: 2.3522 },
+    now
+  );
+  assert.ok(location);
+  const request = createEdgeConfigWriteRequest(location, {
+    EDGE_CONFIG_ID: "ecfg_test",
+    EDGE_CONFIG_WRITE_TOKEN: "write-token",
+    EDGE_CONFIG_TEAM_ID: "team_test",
+  });
+  assert.ok(request);
+  assert.equal(
+    request.url,
+    "https://api.vercel.com/v1/edge-config/ecfg_test/items?teamId=team_test"
+  );
+  assert.equal(request.init.method, "PATCH");
+  assert.equal(
+    (request.init.headers as Record<string, string>).authorization,
+    "Bearer write-token"
+  );
+  assert.deepEqual(JSON.parse(String(request.init.body)), {
+    items: [
+      {
+        operation: "upsert",
+        key: "current_location",
+        value: location,
+      },
+    ],
+  });
+});

--- a/server/location-data.test.ts
+++ b/server/location-data.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  createEdgeConfigWriteRequest,
+  createGlobalConfigWriteRequest,
   hasValidBearerToken,
   parseLocationUpdate,
   parseStoredLocation,
@@ -74,10 +74,10 @@ test("checks bearer tokens and produces the authenticated batch upsert", () => {
     now
   );
   assert.ok(location);
-  const request = createEdgeConfigWriteRequest(location, {
-    EDGE_CONFIG_ID: "ecfg_test",
-    EDGE_CONFIG_WRITE_TOKEN: "write-token",
-    EDGE_CONFIG_TEAM_ID: "team_test",
+  const request = createGlobalConfigWriteRequest(location, {
+    GLOBAL_CONFIG_ID: "ecfg_test",
+    GLOBAL_CONFIG_WRITE_TOKEN: "write-token",
+    GLOBAL_CONFIG_TEAM_ID: "team_test",
   });
   assert.ok(request);
   assert.equal(

--- a/server/location-data.ts
+++ b/server/location-data.ts
@@ -1,0 +1,126 @@
+import { timingSafeEqual } from "node:crypto";
+
+export const CURRENT_LOCATION_KEY = "current_location";
+export interface StoredLocation {
+  version: 1;
+  city: string;
+  country?: string;
+  latitude: number;
+  longitude: number;
+  updatedAt: string;
+}
+
+interface EdgeConfigWriteEnvironment {
+  EDGE_CONFIG_ID?: string;
+  EDGE_CONFIG_WRITE_TOKEN?: string;
+  EDGE_CONFIG_TEAM_ID?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizedText(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().replace(/\s+/g, " ");
+  if (!normalized || normalized.length > maxLength) return undefined;
+  return normalized;
+}
+
+function roundedCoordinate(
+  value: unknown,
+  minimum: number,
+  maximum: number
+): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  if (value < minimum || value > maximum) return undefined;
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+export function parseLocationUpdate(
+  value: unknown,
+  now = new Date()
+): StoredLocation | null {
+  if (!isRecord(value)) return null;
+
+  const city = normalizedText(value.city, 80);
+  const country =
+    value.country === undefined ? undefined : normalizedText(value.country, 80);
+  const latitude = roundedCoordinate(value.latitude, -90, 90);
+  const longitude = roundedCoordinate(value.longitude, -180, 180);
+
+  if (
+    !city ||
+    (value.country !== undefined && !country) ||
+    latitude === undefined ||
+    longitude === undefined ||
+    Number.isNaN(now.getTime())
+  ) {
+    return null;
+  }
+
+  return {
+    version: 1,
+    city,
+    ...(country ? { country } : {}),
+    latitude,
+    longitude,
+    updatedAt: now.toISOString(),
+  };
+}
+
+export function parseStoredLocation(value: unknown): StoredLocation | null {
+  if (!isRecord(value) || value.version !== 1) return null;
+
+  const parsed = parseLocationUpdate(value, new Date(String(value.updatedAt)));
+  return parsed;
+}
+
+export function hasValidBearerToken(
+  authorization: string | null,
+  expectedSecret: string | undefined
+): boolean {
+  if (!authorization?.startsWith("Bearer ") || !expectedSecret) return false;
+
+  const supplied = Buffer.from(authorization.slice(7), "utf8");
+  const expected = Buffer.from(expectedSecret, "utf8");
+  return supplied.length === expected.length && timingSafeEqual(supplied, expected);
+}
+
+export function createEdgeConfigWriteRequest(
+  location: StoredLocation,
+  environment: EdgeConfigWriteEnvironment
+): { url: string; init: RequestInit } | null {
+  const id = environment.EDGE_CONFIG_ID;
+  const token = environment.EDGE_CONFIG_WRITE_TOKEN;
+  if (!id || !token) return null;
+
+  const url = new URL(
+    `https://api.vercel.com/v1/edge-config/${encodeURIComponent(id)}/items`
+  );
+  if (environment.EDGE_CONFIG_TEAM_ID) {
+    url.searchParams.set("teamId", environment.EDGE_CONFIG_TEAM_ID);
+  }
+
+  return {
+    url: url.toString(),
+    init: {
+      method: "PATCH",
+      cache: "no-store",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        items: [
+          {
+            operation: "upsert",
+            key: CURRENT_LOCATION_KEY,
+            value: location,
+          },
+        ],
+      }),
+    },
+  };
+}

--- a/server/location-data.ts
+++ b/server/location-data.ts
@@ -10,10 +10,10 @@ export interface StoredLocation {
   updatedAt: string;
 }
 
-interface EdgeConfigWriteEnvironment {
-  EDGE_CONFIG_ID?: string;
-  EDGE_CONFIG_WRITE_TOKEN?: string;
-  EDGE_CONFIG_TEAM_ID?: string;
+interface GlobalConfigWriteEnvironment {
+  GLOBAL_CONFIG_ID?: string;
+  GLOBAL_CONFIG_WRITE_TOKEN?: string;
+  GLOBAL_CONFIG_TEAM_ID?: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -87,19 +87,19 @@ export function hasValidBearerToken(
   return supplied.length === expected.length && timingSafeEqual(supplied, expected);
 }
 
-export function createEdgeConfigWriteRequest(
+export function createGlobalConfigWriteRequest(
   location: StoredLocation,
-  environment: EdgeConfigWriteEnvironment
+  environment: GlobalConfigWriteEnvironment
 ): { url: string; init: RequestInit } | null {
-  const id = environment.EDGE_CONFIG_ID;
-  const token = environment.EDGE_CONFIG_WRITE_TOKEN;
+  const id = environment.GLOBAL_CONFIG_ID;
+  const token = environment.GLOBAL_CONFIG_WRITE_TOKEN;
   if (!id || !token) return null;
 
   const url = new URL(
     `https://api.vercel.com/v1/edge-config/${encodeURIComponent(id)}/items`
   );
-  if (environment.EDGE_CONFIG_TEAM_ID) {
-    url.searchParams.set("teamId", environment.EDGE_CONFIG_TEAM_ID);
+  if (environment.GLOBAL_CONFIG_TEAM_ID) {
+    url.searchParams.set("teamId", environment.GLOBAL_CONFIG_TEAM_ID);
   }
 
   return {

--- a/server/location.test.ts
+++ b/server/location.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { composeLocationWeather } from "./location";
+import type { StoredLocation } from "./location-data";
+
+const paris: StoredLocation = {
+  version: 1,
+  city: "Paris",
+  country: "France",
+  latitude: 48.86,
+  longitude: 2.35,
+  updatedAt: "2026-08-01T08:00:00.000Z",
+};
+
+test("uses Lisbon as the home base when Edge Config has no valid record", () => {
+  assert.deepEqual(composeLocationWeather(null, null), {
+    location: "Lisbon",
+    country: "Portugal",
+    timeZone: "Europe/Lisbon",
+    temperature: null,
+    condition: null,
+    updatedAt: null,
+    isHomeBase: true,
+  });
+});
+
+test("preserves a saved location during an independent weather outage", () => {
+  assert.deepEqual(composeLocationWeather(paris, null), {
+    location: "Paris",
+    country: "France",
+    timeZone: null,
+    temperature: null,
+    condition: null,
+    updatedAt: paris.updatedAt,
+    isHomeBase: false,
+  });
+});
+
+test("combines the saved location with timezone-aware current weather", () => {
+  assert.deepEqual(
+    composeLocationWeather(paris, {
+      timeZone: "Europe/Paris",
+      temperature: 26,
+      condition: "Clear",
+    }),
+    {
+      location: "Paris",
+      country: "France",
+      timeZone: "Europe/Paris",
+      temperature: 26,
+      condition: "Clear",
+      updatedAt: paris.updatedAt,
+      isHomeBase: false,
+    }
+  );
+});

--- a/server/location.test.ts
+++ b/server/location.test.ts
@@ -12,7 +12,7 @@ const paris: StoredLocation = {
   updatedAt: "2026-08-01T08:00:00.000Z",
 };
 
-test("uses Lisbon as the home base when Edge Config has no valid record", () => {
+test("uses Lisbon as the home base when Global Config has no valid record", () => {
   assert.deepEqual(composeLocationWeather(null, null), {
     location: "Lisbon",
     country: "Portugal",

--- a/server/location.ts
+++ b/server/location.ts
@@ -1,0 +1,75 @@
+import { cacheLife } from "next/cache";
+
+const LISBON_WEATHER_URL =
+  "https://api.open-meteo.com/v1/forecast?latitude=38.7223&longitude=-9.1393&current=temperature_2m,weather_code&timezone=auto";
+
+interface OpenMeteoResponse {
+  current?: {
+    time?: string;
+    temperature_2m?: number;
+    weather_code?: number;
+  };
+}
+
+export interface LocationWeather {
+  location: string;
+  time: string;
+  temperature: number;
+  condition: string;
+}
+
+function describeWeatherCode(code: number): string {
+  if (code === 0) return "Clear";
+  if (code <= 3) return "Partly cloudy";
+  if (code <= 48) return "Foggy";
+  if (code <= 57) return "Drizzle";
+  if (code <= 67) return "Rain";
+  if (code <= 77) return "Snow";
+  if (code <= 82) return "Showers";
+  if (code <= 86) return "Snow showers";
+  return "Thunderstorms";
+}
+
+function formatLocalTime(value: string): string {
+  const match = value.match(/T(\d{2}):(\d{2})/);
+  if (!match) return "Local time";
+
+  const hour = Number(match[1]);
+  const suffix = hour >= 12 ? "PM" : "AM";
+  const twelveHour = hour % 12 || 12;
+  return `${twelveHour}:${match[2]} ${suffix}`;
+}
+
+export async function getLisbonWeather(): Promise<LocationWeather | null> {
+  "use cache";
+  cacheLife("minutes");
+
+  try {
+    const response = await fetch(LISBON_WEATHER_URL, {
+      headers: { accept: "application/json" },
+    });
+
+    if (!response.ok) throw new Error(`Open-Meteo returned ${response.status}`);
+
+    const data = (await response.json()) as OpenMeteoResponse;
+    const current = data.current;
+
+    if (
+      !current?.time ||
+      typeof current.temperature_2m !== "number" ||
+      typeof current.weather_code !== "number"
+    ) {
+      throw new Error("Open-Meteo returned incomplete current conditions");
+    }
+
+    return {
+      location: "Lisbon",
+      time: formatLocalTime(current.time),
+      temperature: Math.round(current.temperature_2m),
+      condition: describeWeatherCode(current.weather_code),
+    };
+  } catch (error) {
+    console.error("Unable to load Lisbon weather", error);
+    return null;
+  }
+}

--- a/server/location.ts
+++ b/server/location.ts
@@ -1,21 +1,59 @@
+import { createClient } from "@vercel/edge-config";
 import { cacheLife } from "next/cache";
+import {
+  CURRENT_LOCATION_KEY,
+  parseStoredLocation,
+  type StoredLocation,
+} from "@/server/location-data";
 
-const LISBON_WEATHER_URL =
-  "https://api.open-meteo.com/v1/forecast?latitude=38.7223&longitude=-9.1393&current=temperature_2m,weather_code&timezone=auto";
+const LISBON_HOME: StoredLocation = {
+  version: 1,
+  city: "Lisbon",
+  country: "Portugal",
+  latitude: 38.72,
+  longitude: -9.14,
+  updatedAt: "",
+};
 
 interface OpenMeteoResponse {
+  timezone?: string;
   current?: {
-    time?: string;
     temperature_2m?: number;
     weather_code?: number;
   };
 }
 
-export interface LocationWeather {
-  location: string;
-  time: string;
+interface CurrentWeather {
+  timeZone: string;
   temperature: number;
   condition: string;
+}
+
+export interface LocationWeather {
+  location: string;
+  country: string | null;
+  timeZone: string | null;
+  temperature: number | null;
+  condition: string | null;
+  updatedAt: string | null;
+  isHomeBase: boolean;
+}
+
+export function composeLocationWeather(
+  savedLocation: StoredLocation | null,
+  weather: CurrentWeather | null
+): LocationWeather {
+  const location = savedLocation ?? LISBON_HOME;
+
+  return {
+    location: location.city,
+    country: location.country ?? null,
+    timeZone: weather?.timeZone ?? (!savedLocation ? "Europe/Lisbon" : null),
+    temperature: weather?.temperature ?? null,
+    condition: weather?.condition ?? null,
+    updatedAt: savedLocation?.updatedAt ?? null,
+    isHomeBase: !savedLocation,
+  };
 }
 
 function describeWeatherCode(code: number): string {
@@ -30,46 +68,74 @@ function describeWeatherCode(code: number): string {
   return "Thunderstorms";
 }
 
-function formatLocalTime(value: string): string {
-  const match = value.match(/T(\d{2}):(\d{2})/);
-  if (!match) return "Local time";
+async function readCurrentLocation(): Promise<StoredLocation | null> {
+  "use cache";
+  cacheLife("seconds");
 
-  const hour = Number(match[1]);
-  const suffix = hour >= 12 ? "PM" : "AM";
-  const twelveHour = hour % 12 || 12;
-  return `${twelveHour}:${match[2]} ${suffix}`;
+  if (!process.env.EDGE_CONFIG) return null;
+
+  try {
+    const edgeConfig = createClient(process.env.EDGE_CONFIG, {
+      cache: "no-store",
+      disableDevelopmentCache: true,
+    });
+    return parseStoredLocation(await edgeConfig.get(CURRENT_LOCATION_KEY));
+  } catch {
+    console.error("Unable to read the current location from Edge Config");
+    return null;
+  }
 }
 
-export async function getLisbonWeather(): Promise<LocationWeather | null> {
+async function getWeatherForCoordinates(
+  latitude: number,
+  longitude: number
+): Promise<CurrentWeather | null> {
   "use cache";
   cacheLife("minutes");
 
-  try {
-    const response = await fetch(LISBON_WEATHER_URL, {
-      headers: { accept: "application/json" },
-    });
+  const params = new URLSearchParams({
+    latitude: latitude.toFixed(2),
+    longitude: longitude.toFixed(2),
+    current: "temperature_2m,weather_code",
+    timezone: "auto",
+  });
 
-    if (!response.ok) throw new Error(`Open-Meteo returned ${response.status}`);
+  try {
+    const response = await fetch(
+      `https://api.open-meteo.com/v1/forecast?${params.toString()}`,
+      { headers: { accept: "application/json" } }
+    );
+    if (!response.ok) throw new Error("Weather service unavailable");
 
     const data = (await response.json()) as OpenMeteoResponse;
-    const current = data.current;
-
     if (
-      !current?.time ||
-      typeof current.temperature_2m !== "number" ||
-      typeof current.weather_code !== "number"
+      !data.timezone ||
+      typeof data.current?.temperature_2m !== "number" ||
+      typeof data.current.weather_code !== "number"
     ) {
-      throw new Error("Open-Meteo returned incomplete current conditions");
+      throw new Error("Weather service returned incomplete conditions");
     }
 
     return {
-      location: "Lisbon",
-      time: formatLocalTime(current.time),
-      temperature: Math.round(current.temperature_2m),
-      condition: describeWeatherCode(current.weather_code),
+      timeZone: data.timezone,
+      temperature: Math.round(data.current.temperature_2m),
+      condition: describeWeatherCode(data.current.weather_code),
     };
-  } catch (error) {
-    console.error("Unable to load Lisbon weather", error);
+  } catch {
+    console.error("Unable to load current weather");
     return null;
   }
+}
+
+export async function getCurrentLocationWeather(): Promise<LocationWeather> {
+  "use cache";
+  cacheLife("seconds");
+
+  const savedLocation = await readCurrentLocation();
+  const location = savedLocation ?? LISBON_HOME;
+  const weather = await getWeatherForCoordinates(
+    location.latitude,
+    location.longitude
+  );
+  return composeLocationWeather(savedLocation, weather);
 }

--- a/server/location.ts
+++ b/server/location.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@vercel/edge-config";
+import { createClient } from "@vercel/global-config";
 import { cacheLife } from "next/cache";
 import {
   CURRENT_LOCATION_KEY,
@@ -72,16 +72,16 @@ async function readCurrentLocation(): Promise<StoredLocation | null> {
   "use cache";
   cacheLife("seconds");
 
-  if (!process.env.EDGE_CONFIG) return null;
+  if (!process.env.GLOBAL_CONFIG) return null;
 
   try {
-    const edgeConfig = createClient(process.env.EDGE_CONFIG, {
+    const globalConfig = createClient(process.env.GLOBAL_CONFIG, {
       cache: "no-store",
       disableDevelopmentCache: true,
     });
-    return parseStoredLocation(await edgeConfig.get(CURRENT_LOCATION_KEY));
+    return parseStoredLocation(await globalConfig.get(CURRENT_LOCATION_KEY));
   } catch {
-    console.error("Unable to read the current location from Edge Config");
+    console.error("Unable to read the current location from Global Config");
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- refresh the homepage introduction with a serif identity, integrated X/GitHub/Spotify links, and live Lisbon weather
- replace the post selector/cards with a mobile-responsive scroll timeline and fixed, cropped image deck
- preload upcoming post images in batches and keep the active title, counter, and image synchronized
- upgrade Next.js to 16.2.12 and use Cache Components for weather data
- allow LAN development access and serve remote Substack images without the failing local optimizer

## Why

The previous homepage separated personal context, music, social links, and writing into disconnected blocks. The post browsing experience also did not remain synchronized on real mobile devices because the LAN dev origin was blocked and the image optimizer failed on some Substack URLs.

This revision turns the page into one continuous narrative and makes the writing timeline work consistently on desktop and mobile.

## Validation

- `npx tsc --noEmit`
- `git diff --check`
- desktop browser verification
- 390 × 844 mobile verification
- cold-load verification through `http://192.168.0.140:3000/`
- confirmed active title/counter/image synchronization and zero browser errors
