### PR TITLE
Fix Next.js production build for location route

### DIFF
--- a/app/api/location/update/route.ts
+++ b/app/api/location/update/route.ts
@@ -5,8 +5,6 @@ import {
   parseLocationUpdate,
 } from "@/server/location-data";
 
-export const runtime = "nodejs";
-
 function json(body: object, status: number) {
   return NextResponse.json(body, {
     status,


### PR DESCRIPTION
Removes the redundant route-level Node.js runtime declaration, which is incompatible with Next.js Cache Components. The route continues to use the default Node.js runtime.\n\nVerified with TypeScript and all 14 location tests.