### PR TITLE
Fix mobile weather popover and persistent post navigation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -59,12 +59,6 @@ body {
   color: white;
 }
 
-/* Smooth View Transitions */
-::view-transition-group(root) {
-  animation-duration: 0.4s;
-  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-}
-
 dialog::backdrop {
   background-color: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(4px);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import { ViewTransition } from "react";
 import { Header } from "../components/app-header";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -27,9 +26,7 @@ export default function RootLayout({
           <main className="max-w-4xl mx-auto px-4 sm:px-8 py-12 container grow">
             <Header />
             <div className="mt-4 sm:mt-12  max-w-xl mx-auto">
-              <ViewTransition>
-                {children}
-              </ViewTransition>
+              {children}
             </div>
           </main>
         </div>

--- a/app/posts/[slug]/layout.tsx
+++ b/app/posts/[slug]/layout.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import PreviousButton from "@/components/posts/post-previous-button";
 import NextButton from "@/components/posts/post-next-button";
 import { fetchSubstackPosts } from "@/server/substack-feed";
@@ -8,6 +7,8 @@ interface LayoutProps {
 }
 
 export default async function SlugLayout({ children }: LayoutProps) {
+  const posts = await fetchSubstackPosts();
+
   return (
     <>
       <div
@@ -17,22 +18,10 @@ export default async function SlugLayout({ children }: LayoutProps) {
         max-w-4xl mx-16 md:px-0 pt-3
         "
       >
-        <Suspense fallback={null}>
-          <PostsNavigation />
-        </Suspense>
+        <PreviousButton posts={posts} />
+        <NextButton posts={posts} />
       </div>
       {children}
-    </>
-  );
-}
-
-async function PostsNavigation() {
-  const posts = await fetchSubstackPosts();
-
-  return (
-    <>
-      <PreviousButton posts={posts} />
-      <NextButton posts={posts} />
     </>
   );
 }

--- a/components/weather-pill.tsx
+++ b/components/weather-pill.tsx
@@ -118,7 +118,7 @@ export default function WeatherPill({ weather }: WeatherPillProps) {
         id="weather-details"
         aria-label={`${weather?.location ?? "Lisbon"} weather details`}
         aria-hidden={!isOpen}
-        className={`absolute right-0 top-[calc(100%+0.5rem)] z-40 w-64 max-w-[calc(100vw-2rem)] origin-top-right rounded-xl border border-border bg-background px-3.5 py-3 text-left text-xs leading-relaxed text-muted shadow-lg transition-[opacity,transform] duration-150 [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
+        className={`absolute left-0 right-auto top-[calc(100%+0.5rem)] z-40 w-64 max-w-[calc(100vw-2rem)] origin-top-left rounded-xl border border-border bg-background px-3.5 py-3 text-left text-xs leading-relaxed text-muted shadow-lg transition-[opacity,transform] duration-150 [transition-timing-function:cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none sm:left-auto sm:right-0 sm:origin-top-right ${
           isOpen
             ? "pointer-events-auto translate-y-0 scale-100 opacity-100"
             : "pointer-events-none -translate-y-1 scale-[0.97] opacity-0"

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,7 +24,6 @@ const nextConfig: NextConfig = {
   allowedDevOrigins: ['localhost', '192.168.1.25', '192.168.0.140'],
   experimental: {
     mdxRs: true,
-    viewTransition: true,
   },
 };
 


### PR DESCRIPTION
- Anchor the weather details panel to the pill's left edge on mobile while retaining desktop alignment.\n- Remove the root-level 400ms View Transition that cross-faded persistent post controls.\n- Resolve post navigation directly in the shared slug layout instead of suspending to a null fallback.\n\nVerified with TypeScript and all 14 location tests.