### PR TITLE
Polish iOS Safari artwork edge

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -43,6 +43,7 @@
 }
 
 html {
+  background-color: var(--background);
   min-width: 360px;
   scrollbar-gutter: stable;
 }
@@ -194,6 +195,21 @@ dialog::backdrop {
 
 .artwork-destack-reveal {
   animation-name: artworkDestackReveal;
+}
+
+/* Let imagery meet iOS Safari's translucent chrome without a hard edge. */
+.artwork-bottom-veil {
+  -webkit-backdrop-filter: blur(3px);
+  backdrop-filter: blur(3px);
+  background: linear-gradient(to top, rgb(253 251 247 / 14%), transparent);
+  -webkit-mask-image: linear-gradient(to top, black, transparent);
+  mask-image: linear-gradient(to top, black, transparent);
+}
+
+@media (prefers-color-scheme: dark) {
+  .artwork-bottom-veil {
+    background: linear-gradient(to top, rgb(20 18 11 / 16%), transparent);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import "./globals.css";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import { Header } from "../components/app-header";
 
@@ -12,6 +12,14 @@ export const metadata: Metadata = {
     template: "%s | Hugo Demenez",
   },
   description: "Developer, trader, and entrepreneur.",
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { color: "#FDFBF7", media: "(prefers-color-scheme: light)" },
+    { color: "#14120b", media: "(prefers-color-scheme: dark)" },
+  ],
+  viewportFit: "cover",
 };
 
 export default function RootLayout({

--- a/components/posts/post-visualizer.tsx
+++ b/components/posts/post-visualizer.tsx
@@ -337,7 +337,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
 
       <div
         data-writing-deck
-        className={`fixed inset-x-4 bottom-[env(safe-area-inset-bottom)] z-30 mx-auto h-[clamp(10rem,38vw,14rem)] max-w-xl overflow-hidden motion-reduce:transition-none ${
+        className={`fixed inset-x-4 bottom-0 z-30 mx-auto h-[clamp(10rem,38vw,14rem)] max-w-xl overflow-hidden motion-reduce:transition-none ${
           isFirstArtwork
             ? "will-change-transform transition-[transform,opacity] duration-[240ms] [transition-timing-function:cubic-bezier(0.23,1,0.32,1)]"
             : "transition-none"
@@ -429,6 +429,11 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
             )}
           </Link>
         </div>
+
+        <div
+          aria-hidden="true"
+          className="artwork-bottom-veil pointer-events-none absolute inset-x-0 bottom-0 z-30 h-7"
+        />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- let the writing artwork extend beneath iOS Safari chrome
- match Safari theme tint and root canvas to the site background in light and dark mode
- add a subtle masked 3px blur at the bottom of the artwork

## Verification
- npm test (14 passing)
- npx tsc --noEmit
- git diff --check