### PR TITLE
Let Safari overlay artwork natively

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -197,21 +197,6 @@ dialog::backdrop {
   animation-name: artworkDestackReveal;
 }
 
-/* Let imagery meet iOS Safari's translucent chrome without a hard edge. */
-.artwork-bottom-veil {
-  -webkit-backdrop-filter: blur(3px);
-  backdrop-filter: blur(3px);
-  background: linear-gradient(to top, rgb(253 251 247 / 14%), transparent);
-  -webkit-mask-image: linear-gradient(to top, black, transparent);
-  mask-image: linear-gradient(to top, black, transparent);
-}
-
-@media (prefers-color-scheme: dark) {
-  .artwork-bottom-veil {
-    background: linear-gradient(to top, rgb(20 18 11 / 16%), transparent);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,10 +15,6 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: [
-    { color: "#FDFBF7", media: "(prefers-color-scheme: light)" },
-    { color: "#14120b", media: "(prefers-color-scheme: dark)" },
-  ],
   viewportFit: "cover",
 };
 

--- a/components/posts/post-visualizer.tsx
+++ b/components/posts/post-visualizer.tsx
@@ -430,10 +430,6 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
           </Link>
         </div>
 
-        <div
-          aria-hidden="true"
-          className="artwork-bottom-veil pointer-events-none absolute inset-x-0 bottom-0 z-30 h-7"
-        />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- remove the custom Safari toolbar theme tint
- remove the blur/cream veil that covered the artwork bottom
- retain viewport-fit=cover and the bottom-zero artwork position so iOS Safari can float its native translucent toolbar over the image

## Verification
- npm test (14 passing)
- npx tsc --noEmit
- git diff --check