### PR TITLE
Fix misspelled Deltalytix link on the homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -198,7 +198,7 @@ export default async function Home() {
             The work itself is less private: I build{" "}
             <a
               className={socialLinkClass}
-              href="https://deltlaytix.app"
+              href="https://deltalytix.app"
               rel="noopener noreferrer"
               target="_blank"
             >


### PR DESCRIPTION
The homepage link pointed at deltlaytix.app instead of deltalytix.app.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AiHHeuaibAuz7dYtzLbZYM