### PR TITLE
Draw timeline highlights with a hand-made highlighter mark

### DIFF
--- a/app/_components/highlighter-text.tsx
+++ b/app/_components/highlighter-text.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface HighlighterTextProps {
+  /** The text the marker sweeps over. Plain text — the range maths reads lines. */
+  children: string;
+  className?: string;
+  /** Stable string the wobble is derived from, so a re-measure redraws the same
+   *  stroke rather than a new one. */
+  seed: string;
+  /** Inline content that trails the text and is left unmarked (a date, say). */
+  trailing?: ReactNode;
+}
+
+interface MarkerStroke {
+  /** Second, narrower pass — where a real nib doubles back and the ink pools. */
+  corePath: string;
+  coreWidth: number;
+  delay: number;
+  duration: number;
+  path: string;
+  width: number;
+}
+
+/**
+ * Hash a string into a small deterministic PRNG (mulberry32 over an FNV-1a seed).
+ * Every stroke shape comes out of this, so the marks look hand-made but never
+ * change under the reader — including between measurements.
+ */
+function createRandom(seed: string): () => number {
+  let hash = 2166136261;
+
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return () => {
+    hash = (hash + 0x6d2b79f5) | 0;
+    let value = hash;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+/** Quadratic smoothing through the midpoints — a nib never travels in facets. */
+function toSmoothPath(points: Point[]): string {
+  if (points.length < 2) return "";
+
+  let path = `M ${points[0].x.toFixed(2)} ${points[0].y.toFixed(2)}`;
+
+  for (let index = 1; index < points.length - 1; index += 1) {
+    const point = points[index];
+    const next = points[index + 1];
+    const midX = (point.x + next.x) / 2;
+    const midY = (point.y + next.y) / 2;
+
+    path += ` Q ${point.x.toFixed(2)} ${point.y.toFixed(2)} ${midX.toFixed(
+      2
+    )} ${midY.toFixed(2)}`;
+  }
+
+  const last = points[points.length - 1];
+  return `${path} L ${last.x.toFixed(2)} ${last.y.toFixed(2)}`;
+}
+
+interface LineBox {
+  height: number;
+  left: number;
+  /** Furthest right the nib may travel, in host coordinates. */
+  limit: number;
+  right: number;
+  top: number;
+}
+
+/**
+ * One pass of the marker over a line: overshoots both ends by a hair, drifts off
+ * level, and wanders vertically the way a hand does.
+ */
+function buildStroke(
+  line: LineBox,
+  random: () => number,
+  lift: number,
+  tilt: number
+): { path: string; width: number } {
+  const start = Math.max(-8, line.left - (2 + random() * 7));
+  const end = Math.min(line.limit, line.right + (3 + random() * 11));
+  const centre = line.top + line.height * lift;
+  const wander = line.height * 0.09;
+  const segments = 4 + Math.floor(random() * 3);
+  const points: Point[] = [];
+
+  for (let index = 0; index <= segments; index += 1) {
+    const progress = index / segments;
+    // Ends stay near the centre line; the wobble peaks mid-stroke.
+    const ease = Math.sin(progress * Math.PI);
+
+    points.push({
+      x: start + (end - start) * progress,
+      y:
+        centre +
+        tilt * (progress - 0.5) * line.height +
+        (random() - 0.5) * 2 * wander * ease,
+    });
+  }
+
+  return { path: toSmoothPath(points), width: end - start };
+}
+
+/**
+ * Draws a hand-made highlighter mark behind its text, one stroke per rendered
+ * line, sweeping left to right as the block scrolls into view.
+ */
+export default function HighlighterText({
+  children,
+  className,
+  seed,
+  trailing,
+}: HighlighterTextProps) {
+  const hostRef = useRef<HTMLSpanElement>(null);
+  const textRef = useRef<HTMLSpanElement>(null);
+  const filterId = `highlighter-${useId().replace(/[^a-zA-Z0-9-]/g, "")}`;
+  const [strokes, setStrokes] = useState<MarkerStroke[]>([]);
+  const [box, setBox] = useState({ height: 0, width: 0 });
+  const [drawn, setDrawn] = useState(false);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    const text = textRef.current;
+    if (!host || !text) return;
+
+    const measure = () => {
+      const hostBox = host.getBoundingClientRect();
+      const range = document.createRange();
+      range.selectNodeContents(text);
+
+      // A line that fills the column has no room left for the overshoot, and the
+      // page gutter is all that stands between the nib and the viewport edge.
+      const overshootLimit = hostBox.width + 8;
+
+      // One rect per rendered line — this is what lets a wrapped sentence get a
+      // separate stroke per line instead of one bar across the whole block.
+      const lines: LineBox[] = Array.from(range.getClientRects())
+        .filter((rect) => rect.width > 1 && rect.height > 1)
+        .map((rect) => ({
+          height: rect.height,
+          left: rect.left - hostBox.left,
+          limit: overshootLimit,
+          right: rect.right - hostBox.left,
+          top: rect.top - hostBox.top,
+        }));
+
+      if (!lines.length) return;
+
+      const random = createRandom(seed);
+      let elapsed = 0;
+
+      setBox({ height: hostBox.height, width: hostBox.width });
+      setStrokes(
+        lines.map((line) => {
+          const lift = 0.54 + random() * 0.07;
+          const tilt = (random() - 0.5) * 0.18;
+          const main = buildStroke(line, random, lift, tilt);
+          // The doubling-back pass rides a touch lower and stops a little short.
+          const core = buildStroke(
+            { ...line, right: line.right - random() * 14 },
+            random,
+            lift + 0.06,
+            tilt * 0.6
+          );
+          const duration = Math.min(560, Math.max(260, main.width * 1.15));
+          const delay = elapsed;
+
+          // Lines overlap slightly, like a hand already moving to the next one.
+          elapsed += duration * 0.78;
+
+          return {
+            corePath: core.path,
+            coreWidth: line.height * 0.42,
+            delay,
+            duration,
+            path: main.path,
+            width: line.height * 0.78,
+          };
+        })
+      );
+    };
+
+    measure();
+
+    // ResizeObserver never fires for a non-replaced inline box, and the host is
+    // one — watch the block that lays it out, and the window as a backstop.
+    const observer = new ResizeObserver(measure);
+    observer.observe(host.parentElement ?? host);
+    window.addEventListener("resize", measure);
+    // Web fonts land after first paint and reflow the lines under the strokes.
+    document.fonts?.ready.then(measure).catch(() => {});
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [children, seed]);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    if (
+      typeof IntersectionObserver === "undefined" ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      setDrawn(true);
+      return;
+    }
+
+    // Two observers, deliberately far apart, so the mark can be drawn again on
+    // a later pass without ever being caught erasing itself on screen.
+    //
+    // Draw: waits until the line has cleared the lower fifth of the screen, so
+    // the stroke lands where the reader is looking rather than at the edge.
+    const drawObserver = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) setDrawn(true);
+      },
+      { rootMargin: "0px 0px -20% 0px", threshold: 0.9 }
+    );
+
+    // Re-arm: only once the line is fully off screen. The gap between the two
+    // conditions is the hysteresis — nothing resets while it is still in view.
+    const armObserver = new IntersectionObserver(
+      (entries) => {
+        if (entries.every((entry) => !entry.isIntersecting)) setDrawn(false);
+      },
+      { threshold: 0 }
+    );
+
+    drawObserver.observe(host);
+    armObserver.observe(host);
+
+    return () => {
+      drawObserver.disconnect();
+      armObserver.disconnect();
+    };
+  }, []);
+
+  return (
+    <span className={`relative ${className ?? ""}`} ref={hostRef}>
+      {strokes.length ? (
+        <svg
+          aria-hidden="true"
+          className="highlighter-ink pointer-events-none absolute left-0 top-0 overflow-visible text-accent-light dark:text-accent"
+          height={box.height}
+          viewBox={`0 0 ${box.width} ${box.height}`}
+          width={box.width}
+        >
+          <defs>
+            {/* Roughs up the edges: a marker bleeds into the paper grain, it
+                does not lay down a clean rectangle. */}
+            <filter
+              filterUnits="userSpaceOnUse"
+              height={box.height + 24}
+              id={filterId}
+              width={box.width + 32}
+              x={-16}
+              y={-12}
+            >
+              <feTurbulence
+                baseFrequency="0.022 0.38"
+                numOctaves={2}
+                result="grain"
+                seed={seed.length * 7}
+                type="fractalNoise"
+              />
+              <feDisplacementMap
+                in="SourceGraphic"
+                in2="grain"
+                scale={3.4}
+                xChannelSelector="R"
+                yChannelSelector="G"
+              />
+            </filter>
+          </defs>
+
+          <g filter={`url(#${filterId})`}>
+            {strokes.map((stroke, index) => (
+              <g key={index}>
+                <path
+                  d={stroke.path}
+                  fill="none"
+                  pathLength={1}
+                  stroke="currentColor"
+                  strokeDasharray="1 1"
+                  strokeDashoffset={drawn ? 0 : 1}
+                  strokeLinecap="butt"
+                  strokeOpacity={0.78}
+                  strokeWidth={stroke.width}
+                  style={{
+                    // Only the drawing direction is animated. Re-arming happens
+                    // off screen and must be instant, or a quick scroll back
+                    // catches the mark halfway through erasing itself.
+                    transition: drawn
+                      ? `stroke-dashoffset ${stroke.duration}ms cubic-bezier(0.3,0.7,0.4,1) ${stroke.delay}ms`
+                      : "none",
+                  }}
+                />
+                <path
+                  d={stroke.corePath}
+                  fill="none"
+                  pathLength={1}
+                  stroke="currentColor"
+                  strokeDasharray="1 1"
+                  strokeDashoffset={drawn ? 0 : 1}
+                  strokeLinecap="butt"
+                  strokeOpacity={0.5}
+                  strokeWidth={stroke.coreWidth}
+                  style={{
+                    transition: drawn
+                      ? `stroke-dashoffset ${stroke.duration}ms cubic-bezier(0.3,0.7,0.4,1) ${
+                          stroke.delay + stroke.duration * 0.16
+                        }ms`
+                      : "none",
+                  }}
+                />
+              </g>
+            ))}
+          </g>
+        </svg>
+      ) : null}
+
+      <span className="relative" ref={textRef}>
+        {children}
+      </span>
+      {trailing}
+    </span>
+  );
+}

--- a/app/_components/post-visualizer.tsx
+++ b/app/_components/post-visualizer.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from "react";
 import type { SubstackPost } from "@/types/substack-post";
+import HighlighterText from "./highlighter-text";
 import { PinnedShell } from "./pinned-shell";
 
 interface PostsVisualizerProps {
@@ -282,29 +283,30 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
             return (
               <li
                 key={milestone.id}
-                className="relative grid min-h-28 grid-cols-[1.5rem_1fr] items-center gap-3 sm:grid-cols-[1.75rem_1fr] sm:gap-4"
+                className="relative grid min-h-24 grid-cols-[1.5rem_1fr] items-center gap-3 sm:grid-cols-[1.75rem_1fr] sm:gap-4"
                 data-timeline-highlight={milestone.id}
               >
                 <span
                   aria-hidden="true"
-                  className="relative z-10 mx-auto size-3 rounded-full border-2 border-background bg-accent shadow-[0_0_0_1px_var(--accent)]"
+                  className="relative z-10 mx-auto size-2.5 rounded-full border-2 border-background bg-accent"
                 />
-                <div className="my-4 rounded-xl border border-accent/20 bg-accent/[0.07] px-4 py-3.5">
-                  <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-                    <span className="text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-accent">
-                      Highlight
-                    </span>
-                    <time
-                      className="text-xs font-medium tabular-nums text-muted/60"
-                      dateTime={milestone.date}
-                    >
-                      {milestone.label}
-                    </time>
-                  </div>
-                  <p className="mt-1.5 font-serif text-lg leading-snug tracking-[-0.015em] text-foreground">
+                {/* Same type as a post title — the marker, not a card, is what
+                    sets a highlight apart. */}
+                <p className="my-5 max-w-prose text-[1.05rem] font-bold leading-snug tracking-[-0.015em] text-foreground">
+                  <HighlighterText
+                    seed={milestone.id}
+                    trailing={
+                      <time
+                        className="ml-2 whitespace-nowrap text-sm font-normal tracking-normal text-muted/70"
+                        dateTime={milestone.date}
+                      >
+                        • {milestone.label}
+                      </time>
+                    }
+                  >
                     {milestone.text}
-                  </p>
-                </div>
+                  </HighlighterText>
+                </p>
               </li>
             );
           }

--- a/app/globals.css
+++ b/app/globals.css
@@ -79,6 +79,23 @@ body {
   );
 }
 
+/* Highlighter ink sits behind the text and blends with the paper rather than
+   painting over it: multiply darkens the cream, screen lifts the dark page.
+   The ink colour itself runs the opposite way from the text it sits under —
+   see the accent-light/accent pair on the marker's own classes. */
+.highlighter-ink {
+  mix-blend-mode: multiply;
+}
+
+/* Screen over the dark page runs hot at full strength — pull it back so the
+   ink stays a highlight rather than a glow. */
+@media (prefers-color-scheme: dark) {
+  .highlighter-ink {
+    mix-blend-mode: screen;
+    opacity: 0.52;
+  }
+}
+
 ::selection {
   background-color: var(--accent);
   color: white;


### PR DESCRIPTION
Milestone entries in the Writing timeline were bordered accent cards with an uppercase "Highlight" eyebrow — chrome doing the work the content should do. They now use the same type as a post title, marked with a highlighter stroke that draws itself as the row scrolls into view.

## What changed

**New — `app/_components/highlighter-text.tsx`**

- **Per-line strokes.** Ranges over the text node and reads `getClientRects()`, so a wrapped sentence gets one stroke *per rendered line*, like an actual marker — not one bar behind the block.
- **Random but stable.** Overshoot, tilt, vertical wander and segment count come from a mulberry32 PRNG seeded on the milestone id. Every mark differs; a given mark is identical across re-measures.
- **Two passes + grain.** A narrower second pass rides lower and stops short (the ink pooling where a nib doubles back), and an `feTurbulence` + `feDisplacementMap` filter roughs the outline so it bleeds into the paper.
- **Draws on scroll**, then re-arms. See below.

**Changed — `app/_components/post-visualizer.tsx`, `app/globals.css`**

Card chrome removed; the milestone is now post-title type (`text-[1.05rem]`, bold, matching tracking and `• date` suffix). The ink runs opposite to the type it sits under — pale accent `multiply` over the cream page, deep accent `screen` at 0.52 over the dark one — so bold text stays legible through the mark in both themes.

## Animation trigger

Two `IntersectionObserver`s, neither self-disconnecting:

| | root | fires when | effect |
|---|---|---|---|
| draw | viewport minus bottom 20% | 90% of the line is inside | `drawn = true` |
| re-arm | full viewport | 0% of the line is inside | `drawn = false` |

The gap between those conditions is deliberate hysteresis — re-arming only when the row is *fully* off screen means a mark is never caught erasing itself. For the same reason the reset is untransitioned; with the transition left on, a fast scroll back would re-enter mid-erase and draw forward from a partial state.

Motion itself is CSS, not JS: `pathLength={1}` normalizes every path so one dash pattern fits all strokes, and a `stroke-dashoffset` transition runs the sweep on the compositor. Per-line duration scales with stroke width (`clamp(260, w * 1.15, 560)`) and each line starts before the last finishes.

## Two findings worth a reviewer's attention

- **`ResizeObserver` does not fire for non-replaced inline boxes**, and the host span is one. Observing it directly left geometry stale after a resize — the mark spilled past the viewport edge at 375px. It now observes the parent block with a `window.resize` backstop, and the nib is clamped to the column + 8px.
- **Tailwind's pipeline strips custom-property declarations from plain class rules.** `--highlighter-ink` vanished from the built stylesheet while `mix-blend-mode` in the same rule survived. Strokes use `currentColor` with `text-accent-light dark:text-accent` instead. Worth remembering for future non-`:root` variables in `globals.css`.

## Accessibility

`prefers-reduced-motion: reduce` (or a missing `IntersectionObserver`) skips both observers and renders the mark fully inked — no sweep, nothing to re-trigger. The SVG is `aria-hidden`; text content and the `<time>` element are unchanged.

## Testing

Verified in-browser at 375 / 440 / 520px, light and dark:

- Draw sequence sampled live — line 1 draws, line 2 follows ~330ms later, settled by ~660ms.
- Full round trip — draws, resets to `1.00` off screen, re-draws with the same stagger on re-entry.
- No reset while partly visible: nudged until the row clipped the top edge (`top -68, bottom 41`), offsets held at `0.00`.
- Resize re-measure: SVG width tracks the host, ink stays inside the content column.

`npx tsc --noEmit` and `npm run build` both pass. `npx eslint` fails on a missing `@eslint/js` dependency — pre-existing on this checkout, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)