### PR TITLE
Replace the homepage trading bars with a live candlestick ticker

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -155,6 +155,81 @@ dialog::backdrop {
   }
 }
 
+/* Live candle strip. A candle opens every 1.5s, so the track steps one slot (4
+   user units) left six times over a 9s cycle — a quick 0.4s slide, then a 1.1s
+   hold while the new candle prints. Six steps cover the whole cycle, which lands
+   on a frame identical to the first, so the loop has no seam. Candles leaving on
+   the left are retired by the viewBox clip and the mask's fade. */
+@keyframes tradingCandleScroll {
+  0% {
+    transform: translateX(0);
+  }
+  4.444% {
+    transform: translateX(-4px);
+  }
+  16.667% {
+    transform: translateX(-4px);
+  }
+  21.111% {
+    transform: translateX(-8px);
+  }
+  33.333% {
+    transform: translateX(-8px);
+  }
+  37.778% {
+    transform: translateX(-12px);
+  }
+  50% {
+    transform: translateX(-12px);
+  }
+  54.444% {
+    transform: translateX(-16px);
+  }
+  66.667% {
+    transform: translateX(-16px);
+  }
+  71.111% {
+    transform: translateX(-20px);
+  }
+  83.333% {
+    transform: translateX(-20px);
+  }
+  87.778% {
+    transform: translateX(-24px);
+  }
+  100% {
+    transform: translateX(-24px);
+  }
+}
+
+/* Each candle prints during its own 1.5s slot — 16.667% of the 9s cycle — then
+   holds closed for the rest of it while the track carries it off to the left.
+   Staggered animation-delay is what assigns each candle its slot. */
+@keyframes tradingCandlePrint {
+  0% {
+    transform: scaleY(0);
+  }
+  6% {
+    transform: scaleY(0.62);
+  }
+  11% {
+    transform: scaleY(1.08);
+  }
+  16.5%,
+  100% {
+    transform: scaleY(1);
+  }
+}
+
+.trading-candle-track {
+  animation: tradingCandleScroll 9s ease-out infinite;
+}
+
+.trading-candle {
+  animation: tradingCandlePrint 9s ease-out infinite backwards;
+  transform-box: view-box;
+}
+
 /* Writing artwork deck: stack forward, peel the top card away in reverse. */
 @keyframes artworkStackIn {
   from {
@@ -265,6 +340,8 @@ dialog::backdrop {
     }
   }
 
+  .trading-candle-track,
+  .trading-candle,
   .artwork-stack-in,
   .artwork-stack-under,
   .artwork-destack-out,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,13 +71,13 @@ function TradingBarsIcon() {
         <animate
           attributeName="height"
           values="4;7;3;6;4"
-          dur="1.6s"
+          dur="3.2s"
           repeatCount="indefinite"
         />
         <animate
           attributeName="y"
           values="7;4;8;5;7"
-          dur="1.6s"
+          dur="3.2s"
           repeatCount="indefinite"
         />
       </rect>
@@ -85,13 +85,13 @@ function TradingBarsIcon() {
         <animate
           attributeName="height"
           values="7;3;8;4;7"
-          dur="1.4s"
+          dur="3s"
           repeatCount="indefinite"
         />
         <animate
           attributeName="y"
           values="4;8;3;7;4"
-          dur="1.4s"
+          dur="3s"
           repeatCount="indefinite"
         />
       </rect>
@@ -99,13 +99,13 @@ function TradingBarsIcon() {
         <animate
           attributeName="height"
           values="5;8;4;7;5"
-          dur="1.8s"
+          dur="3.4s"
           repeatCount="indefinite"
         />
         <animate
           attributeName="y"
           values="6;3;7;4;6"
-          dur="1.8s"
+          dur="3.4s"
           repeatCount="indefinite"
         />
       </rect>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,7 +59,31 @@ function SpotifyIcon() {
   );
 }
 
-function TradingBarsIcon() {
+/* One cycle of the price walk. y grows downward, so a close above an open means a
+   smaller number. The last close returns to the first open, which is what lets the
+   strip repeat without a visible seam. */
+const CANDLE_CYCLE = [
+  { open: 10.0, close: 7.6, high: 6.64, low: 11.12 },
+  { open: 7.6, close: 4.72, high: 3.76, low: 8.4 },
+  { open: 4.72, close: 6.16, high: 3.6, low: 7.44 },
+  { open: 6.16, close: 3.12, high: 1.84, low: 6.96 },
+  { open: 3.12, close: 6.64, high: 2.32, low: 7.76 },
+  { open: 6.64, close: 10.0, high: 5.84, low: 10.96 },
+];
+
+const CANDLE_PITCH = 4;
+const VISIBLE_CANDLES = 3;
+const CANDLE_STEP_SECONDS = 1.5;
+
+function TradingCandlestickIcon() {
+  /* Three slots are on screen at once, so the strip carries the cycle plus two
+     lead-in candles: after scrolling a full cycle the window frames candles 6-8,
+     which are identical to 0-2, and the animation can loop from the top. */
+  const candles = Array.from(
+    { length: CANDLE_CYCLE.length + VISIBLE_CANDLES },
+    (_, index) => ({ ...CANDLE_CYCLE[index % CANDLE_CYCLE.length], index }),
+  );
+
   return (
     <svg
       aria-hidden="true"
@@ -67,48 +91,66 @@ function TradingBarsIcon() {
       viewBox="0 0 12 12"
       fill="none"
     >
-      <rect x="1" y="7" width="2.5" height="4" rx="0.75" className="fill-current">
-        <animate
-          attributeName="height"
-          values="4;7;3;6;4"
-          dur="3.2s"
-          repeatCount="indefinite"
-        />
-        <animate
-          attributeName="y"
-          values="7;4;8;5;7"
-          dur="3.2s"
-          repeatCount="indefinite"
-        />
-      </rect>
-      <rect x="4.75" y="4" width="2.5" height="7" rx="0.75" className="fill-current">
-        <animate
-          attributeName="height"
-          values="7;3;8;4;7"
-          dur="3s"
-          repeatCount="indefinite"
-        />
-        <animate
-          attributeName="y"
-          values="4;8;3;7;4"
-          dur="3s"
-          repeatCount="indefinite"
-        />
-      </rect>
-      <rect x="8.5" y="6" width="2.5" height="5" rx="0.75" className="fill-current">
-        <animate
-          attributeName="height"
-          values="5;8;4;7;5"
-          dur="3.4s"
-          repeatCount="indefinite"
-        />
-        <animate
-          attributeName="y"
-          values="6;3;7;4;6"
-          dur="3.4s"
-          repeatCount="indefinite"
-        />
-      </rect>
+      <defs>
+        {/* Held in screen space, so it doubles as depth (older candles sit dimmer)
+            and as the dissolve that retires a candle at the left edge. */}
+        <linearGradient
+          id="tradingCandleFade"
+          gradientUnits="userSpaceOnUse"
+          x1="0"
+          x2="12"
+        >
+          <stop offset="0" stopColor="#fff" stopOpacity="0" />
+          <stop offset="0.1" stopColor="#fff" stopOpacity="0.32" />
+          <stop offset="0.42" stopColor="#fff" stopOpacity="0.62" />
+          <stop offset="0.71" stopColor="#fff" stopOpacity="1" />
+        </linearGradient>
+        <mask
+          id="tradingCandleMask"
+          maskUnits="userSpaceOnUse"
+          x="0"
+          y="0"
+          width="12"
+          height="12"
+        >
+          <rect width="12" height="12" fill="url(#tradingCandleFade)" />
+        </mask>
+      </defs>
+      <g mask="url(#tradingCandleMask)">
+        <g className="trading-candle-track">
+          {candles.map(({ open, close, high, low, index }) => {
+            const x = 2 + index * CANDLE_PITCH;
+            return (
+              <g
+                key={index}
+                className="trading-candle"
+                style={{
+                  /* Print outward from the open price, the way a live candle does. */
+                  transformOrigin: `0 ${open}px`,
+                  animationDelay: `${(index - VISIBLE_CANDLES) * CANDLE_STEP_SECONDS}s`,
+                }}
+              >
+                <line
+                  x1={x}
+                  x2={x}
+                  y1={high}
+                  y2={low}
+                  stroke="currentColor"
+                  strokeWidth="0.55"
+                />
+                <rect
+                  x={x - 1.2}
+                  y={Math.min(open, close)}
+                  width="2.4"
+                  height={Math.abs(close - open)}
+                  rx="0.2"
+                  className="fill-current"
+                />
+              </g>
+            );
+          })}
+        </g>
+      </g>
     </svg>
   );
 }
@@ -162,7 +204,7 @@ export default async function Home() {
           <p className="leading-relaxed">
             I write about the work as I go: building products, staying focused,
             discretionary trading
-            <TradingBarsIcon />
+            <TradingCandlestickIcon />
             and turning rough ideas into useful systems.
             {track ? (
               <>


### PR DESCRIPTION
The inline glyph next to "discretionary trading" was three SMIL-animated bars. It's now a scrolling candlestick chart: a candle opens every 1.5s, prints from its open price, closes, and the track carries it left until it dissolves off the edge.

Still a server component — no client JS ships for a decorative glyph.

## Why a rewrite rather than a tweak

Four things were wrong, and three of them aren't visible by reading the diff:

- **SMIL ignores `prefers-reduced-motion`.** The old bars kept moving for users who asked for less motion. Both new animations are CSS and sit in the existing reduce block.
- **The first candlestick pass moved sub-pixel.** It used `translateY(-0.7px)`. Inside an SVG that's a *user-space* unit, so at 12 units → 14px it resolved to **0.82 device px** — it rendered as faint blur, not motion. Scaling the body instead gives ~2.2px of real travel. On top of that, 45% of the old 4.2s cycle was a static hold.
- **Bodies didn't read as bodies.** `1.7` body against a `0.75` round-capped wick is ~2:1, so each candle looked like a fat pin. Now `2.4` against a `0.55` butt-capped wick (4.4:1).
- **The price tick was genuinely clipped.** It ran to `x=11.65`; its round cap reached `12.025`, past the viewBox, so the SVG root sheared it flat. That was the "broken" look. Removed.

## How the ticker works

Two animations on a shared 9s timeline:

- **The track** steps one slot (4 user units) left six times — 0.4s eased slide, then 1.1s hold. 6 × 1.5s = the 9s cycle.
- **Each candle** prints during its own 1.5s slot via `scaleY`, then holds closed. `animation-delay` is what assigns the slot (`(index - 3) × 1.5s`), so all nine candles share one keyframe set.

The seam is handled by construction: the cycle's last close returns to the first open, so after a full scroll the window frames candles 6–8 — the same shapes as 0–2 — and the loop closes cleanly.

## Two design calls worth a look

**Retirement is a fade, not a clip.** A candle hard-vanishing every 1.5s would pop. The `linearGradient` mask is held in *screen* space, outside the moving track, so it does double duty: it dissolves candles at the left edge and doubles as the depth ramp. A per-candle opacity would have scrolled along with the candles instead of staying put.

**Scaling anchors on the open price, not the bottom.** The cycle has both up and down candles, so "grow from the bottom" would be wrong half the time. Each candle carries an inline `transform-origin: 0 {open}px` with `transform-box: view-box`.

## Verification

Measured against the live DOM, not eyeballed:

- **The loop is seamless** — screen-space geometry of every visible shape at `t=0` and `t=8999.99` is byte-identical.
- **The right candle prints at each step** — sampled all nine across the cycle; the printing one is always the newly-arrived rightmost (4→5→6→7→8).
- **One candle's full lifecycle** (candle 4): invisible off-screen at x=14.9 → slides in while printing → lands in the rightmost slot → overshoots to 1.06 → settles to 1.00 → carried left, closed.

Checked in light and dark. `tsc --noEmit` clean, `npm run build` passes.

## Note for the reviewer

This branch carries `8e40de3 "fix: slow chart animation down"`, which was sitting unpushed on local `main`. It tunes the same icon's SMIL durations and is fully superseded here — the `<animate>` elements it edited no longer exist. Same line of work, so I left it in the lineage rather than dropping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)