### PR TITLE
Show this week's most-played Spotify track

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,12 @@ returns `200` with the city and `updatedAt` fields.
 
 ### Spotify authorization
 
-The footer reads user-specific Spotify data with the Authorization Code flow. Configure
-`SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REDIRECT_URI`, and
-`SPOTIFY_REFRESH_TOKEN` in the deployment environment.
+The homepage reads user-specific Spotify data with the Authorization Code flow
+and shows the most-played track from the last seven days. Spotify only returns
+the 50 most recent plays, so a heavy listening week is ranked from that window
+rather than a complete seven-day history. Configure `SPOTIFY_CLIENT_ID`,
+`SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REDIRECT_URI`, and `SPOTIFY_REFRESH_TOKEN` in
+the deployment environment.
 
 Spotify refresh tokens expire after six months from July 20, 2026. When Spotify returns
 `invalid_grant`, the site stops retrying that token and serves the fallback track. To

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -182,7 +182,7 @@ const musicLinkClass =
   "font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:text-accent";
 
 export default async function Home() {
-  const { recentTrack: track } = await getSpotifyData();
+  const { weeklyTopTrack: track } = await getSpotifyData();
 
   return (
     <>
@@ -208,7 +208,7 @@ export default async function Home() {
             and turning rough ideas into useful systems.
             {track ? (
               <>
-                {" "}Most days have a soundtrack; lately it has been{" "}
+                {" "}Most days have a soundtrack; this week it has been{" "}
                 <a
                   className={musicLinkClass}
                   href={track.url}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "start": "next start",
     "sync-substack": "tsx scripts/sync-substack-posts.ts",
-    "test": "tsx --test server/location-data.test.ts server/location.test.ts lib/location-display.test.ts app/api/location/update/route.test.ts"
+    "test": "tsx --test server/location-data.test.ts server/location.test.ts server/spotify.test.ts lib/location-display.test.ts app/api/location/update/route.test.ts"
   },
   "dependencies": {
     "@next/mdx": "^16.0.0",

--- a/server/spotify.test.ts
+++ b/server/spotify.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mostListenedTrack, type RecentlyPlayedItem } from "./spotify";
+
+const now = new Date("2026-08-14T12:00:00.000Z");
+
+function track(
+  id: string,
+  name: string,
+  artist = "Artist"
+): NonNullable<RecentlyPlayedItem["track"]> {
+  return {
+    id,
+    name,
+    external_urls: { spotify: `https://open.spotify.com/track/${id}` },
+    artists: [{ name: artist }],
+    album: { images: [{ url: `https://i.scdn.co/image/${id}` }] },
+  };
+}
+
+function play(
+  id: string,
+  playedAt: string,
+  name = id
+): RecentlyPlayedItem {
+  return { played_at: playedAt, track: track(id, name) };
+}
+
+test("returns null when nothing was played in the window", () => {
+  assert.equal(mostListenedTrack([], now), null);
+  assert.equal(
+    mostListenedTrack(
+      [play("old", "2026-08-01T12:00:00.000Z", "Old Song")],
+      now
+    ),
+    null
+  );
+});
+
+test("picks the track with the most plays in the past seven days", () => {
+  const result = mostListenedTrack(
+    [
+      play("once", "2026-08-14T10:00:00.000Z", "Once"),
+      play("repeat", "2026-08-13T10:00:00.000Z", "Repeat"),
+      play("repeat", "2026-08-12T10:00:00.000Z", "Repeat"),
+      play("repeat", "2026-08-11T10:00:00.000Z", "Repeat"),
+      play("old", "2026-08-01T10:00:00.000Z", "Old Song"),
+    ],
+    now
+  );
+
+  assert.deepEqual(result, {
+    name: "Repeat",
+    artist: "Artist",
+    albumArt:
+      "/api/image-proxy?url=" +
+      encodeURIComponent("https://i.scdn.co/image/repeat"),
+    url: "https://open.spotify.com/track/repeat",
+  });
+});
+
+test("breaks ties toward the more recently played track", () => {
+  const result = mostListenedTrack(
+    [
+      play("older-tie", "2026-08-10T09:00:00.000Z", "Older Tie"),
+      play("older-tie", "2026-08-10T08:00:00.000Z", "Older Tie"),
+      play("newer-tie", "2026-08-14T09:00:00.000Z", "Newer Tie"),
+      play("newer-tie", "2026-08-13T09:00:00.000Z", "Newer Tie"),
+    ],
+    now
+  );
+
+  assert.equal(result?.name, "Newer Tie");
+});
+
+test("ignores plays without a track id or a valid timestamp", () => {
+  const result = mostListenedTrack(
+    [
+      { played_at: "2026-08-14T10:00:00.000Z", track: null },
+      {
+        played_at: "not-a-date",
+        track: track("bad-date", "Bad Date"),
+      },
+      {
+        played_at: "2026-08-14T10:00:00.000Z",
+        track: { ...track("missing-id", "Missing"), id: undefined },
+      },
+      play("kept", "2026-08-14T11:00:00.000Z", "Kept"),
+    ],
+    now
+  );
+
+  assert.equal(result?.name, "Kept");
+});

--- a/server/spotify.ts
+++ b/server/spotify.ts
@@ -11,18 +11,37 @@ export interface Track {
 
 export interface SpotifyData {
   recentTrack: Track | null;
-  topTracks: Track[];
+  weeklyTopTrack: Track | null;
 }
 
-const FALLBACK_DATA: SpotifyData = {
-  recentTrack: {
-    name: "La Vie en Rose",
-    artist: "Edith Piaf",
-    albumArt: "/api/image-proxy?url=" + encodeURIComponent("https://i.scdn.co/image/ab67616d00001e023d69a1082b9d676263912178"),
-    url: "spotify:track:6RKuyWarJu8SMrflntmyXx",
-  },
-  topTracks: [],
+export const WEEKLY_LISTEN_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+const FALLBACK_TRACK: Track = {
+  name: "La Vie en Rose",
+  artist: "Edith Piaf",
+  albumArt:
+    "/api/image-proxy?url=" +
+    encodeURIComponent("https://i.scdn.co/image/ab67616d00001e023d69a1082b9d676263912178"),
+  url: "spotify:track:6RKuyWarJu8SMrflntmyXx",
 };
+
+const FALLBACK_DATA: SpotifyData = {
+  recentTrack: FALLBACK_TRACK,
+  weeklyTopTrack: FALLBACK_TRACK,
+};
+
+interface SpotifyTrack {
+  id?: string;
+  name: string;
+  external_urls: { spotify: string };
+  artists: { name: string }[];
+  album: { images: { url: string }[] };
+}
+
+export interface RecentlyPlayedItem {
+  played_at: string;
+  track?: SpotifyTrack | null;
+}
 
 interface SpotifyTokenResponse {
   access_token?: string;
@@ -78,12 +97,7 @@ async function getAccessToken(
   return data.access_token;
 }
 
-function formatTrack(item: {
-  name: string;
-  external_urls: { spotify: string };
-  artists: { name: string }[];
-  album: { images: { url: string }[] };
-}): Track {
+function formatTrack(item: SpotifyTrack): Track {
   return {
     name: item.name,
     artist: item.artists.map((a) => a.name).join(", "),
@@ -92,6 +106,52 @@ function formatTrack(item: {
       encodeURIComponent(item.album.images[1]?.url ?? item.album.images[0]?.url),
     url: item.external_urls.spotify,
   };
+}
+
+export function mostListenedTrack(
+  items: RecentlyPlayedItem[],
+  now: Date,
+  windowMs = WEEKLY_LISTEN_WINDOW_MS
+): Track | null {
+  const cutoff = now.getTime() - windowMs;
+  const counts = new Map<
+    string,
+    { count: number; lastPlayed: number; track: SpotifyTrack }
+  >();
+
+  for (const item of items) {
+    const track = item.track;
+    if (!track?.id) continue;
+
+    const playedAt = Date.parse(item.played_at);
+    if (Number.isNaN(playedAt) || playedAt < cutoff) continue;
+
+    const existing = counts.get(track.id);
+    if (existing) {
+      existing.count += 1;
+      if (playedAt > existing.lastPlayed) {
+        existing.lastPlayed = playedAt;
+        existing.track = track;
+      }
+    } else {
+      counts.set(track.id, { count: 1, lastPlayed: playedAt, track });
+    }
+  }
+
+  let best:
+    | { count: number; lastPlayed: number; track: SpotifyTrack }
+    | undefined;
+  for (const entry of counts.values()) {
+    if (
+      !best ||
+      entry.count > best.count ||
+      (entry.count === best.count && entry.lastPlayed > best.lastPlayed)
+    ) {
+      best = entry;
+    }
+  }
+
+  return best ? formatTrack(best.track) : null;
 }
 
 export async function getSpotifyData(): Promise<SpotifyData> {
@@ -111,21 +171,21 @@ export async function getSpotifyData(): Promise<SpotifyData> {
     );
     const headers = { Authorization: `Bearer ${accessToken}` };
 
-    const [recentRes, topRes] = await Promise.all([
-      fetch("https://api.spotify.com/v1/me/player/recently-played?limit=1", { headers }),
-      fetch("https://api.spotify.com/v1/me/top/tracks?limit=5&time_range=medium_term", { headers }),
-    ]);
+    const recentRes = await fetch(
+      "https://api.spotify.com/v1/me/player/recently-played?limit=50",
+      { headers }
+    );
+    const recentData = (await recentRes.json()) as {
+      items?: RecentlyPlayedItem[];
+    };
+    const items = recentData.items ?? [];
 
-    const recentData = await recentRes.json();
-    const topData = await topRes.json();
+    const recentTrack = items[0]?.track
+      ? formatTrack(items[0].track)
+      : FALLBACK_TRACK;
+    const weeklyTopTrack = mostListenedTrack(items, new Date()) ?? recentTrack;
 
-    const recentTrack = recentData.items?.[0]?.track
-      ? formatTrack(recentData.items[0].track)
-      : FALLBACK_DATA.recentTrack;
-
-    const topTracks = topData.items?.map(formatTrack) ?? [];
-
-    return { recentTrack, topTracks };
+    return { recentTrack, weeklyTopTrack };
   } catch {
     return FALLBACK_DATA;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Yes — the homepage can show the track you’ve played most in the past 7 days.

Spotify has no official “last 7 days” top-tracks range (`short_term` is about 4 weeks). This change ranks the last 50 recently played tracks by play count inside a 7-day window and uses that on the intro line:

> Most days have a soundtrack; this week it has been **{track}** by **{artist}**.

If nothing in that window ranks, it falls back to the most recent play (then the existing Edith Piaf fallback).

**Limitation:** Spotify only returns the 50 most recent plays. A heavy listening week is ranked from that window, not a complete 7-day history. A full week would need stored play history.

The unused `medium_term` top-tracks fetch is removed. Ranking is covered by unit tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fff8b-7d5c-7838-8c5e-14237402cd49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fff8b-7d5c-7838-8c5e-14237402cd49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

