### PR TITLE
Fix the production build after the Running section merge

### DIFF
--- a/server/spotify.ts
+++ b/server/spotify.ts
@@ -1,4 +1,3 @@
-"use server";
 import { createHash } from "node:crypto";
 import { cacheLife } from "next/cache";
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The production deploy of #30 failed. It was not the Running cards.

`server/spotify.ts` had a file-level `"use server"`, so every export became a Server Action. #31 exported the sync helper `mostListenedTrack` from that file, and Next rejected the build:

```
Server Actions must be async functions.
> export function mostListenedTrack(
```

That same error was already failing production on #31 (`dpl_59V6fcwFCt5LSwA1Y2f91mZcNPLG`). Merging #30 surfaced it again (`dpl_6F6Aym1S1vX4nQPqUbrk4LE8ffqE`).

This file is a server data module, not a client-callable action file. Removing the directive lets `next build` succeed. Local `npm test` and `npm run build` both pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fff80-dde5-7574-9d80-90483be230c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fff80-dde5-7574-9d80-90483be230c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

