### PR TITLE
Rewrite the February 2026 timeline milestone around Foundever

### DIFF
--- a/app/_components/post-visualizer.tsx
+++ b/app/_components/post-visualizer.tsx
@@ -36,9 +36,9 @@ interface TimelineMilestone {
 const TIMELINE_MILESTONES: TimelineMilestone[] = [
   {
     date: "2026-02-01T00:00:00.000Z",
-    id: "joined-a-large-tech-company",
+    id: "joined-foundever",
     label: "February 2026",
-    text: "Joined a large technology company after three years of building on my own, still learning.",
+    text: "Joined Foundever after three years of building on my own, still learning while building an AI gateway and other tools for developers.",
   },
   {
     date: "2025-07-01T00:00:00.000Z",

--- a/app/_components/post-visualizer.tsx
+++ b/app/_components/post-visualizer.tsx
@@ -36,9 +36,9 @@ interface TimelineMilestone {
 const TIMELINE_MILESTONES: TimelineMilestone[] = [
   {
     date: "2026-02-01T00:00:00.000Z",
-    id: "first-developer-role",
+    id: "joined-a-large-tech-company",
     label: "February 2026",
-    text: "Started my first developer role at a large technology company.",
+    text: "Joined a large technology company after three years of building on my own, still learning.",
   },
   {
     date: "2025-07-01T00:00:00.000Z",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The writing timeline still treated February 2026 as a first job at “a large technology company.” That didn’t match the years of independent work, and it hid both the company and what you’re actually building.

The milestone now names Foundever, keeps the three years of building on your own, and frames it as a learning chapter — working on an AI gateway and other tools for developers.

![February 2026 timeline milestone naming Foundever](https://cursor.com/artifacts/c/art-ebd3be59-1eda-422f-9f25-574aba8e6b05)

If you want it shorter, a couple of alternatives:

- `Joined Foundever after three years of building on my own, working on an AI gateway and other tools for developers.`
- `Joined Foundever after three years of building on my own, still learning — now on an AI gateway and other developer tooling.`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9e313be-569d-41ec-b8ba-b907380b0af4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9e313be-569d-41ec-b8ba-b907380b0af4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

