### PR TITLE
Compact Writing posts with inline thumbnails

### DIFF
--- a/app/_components/post-visualizer.tsx
+++ b/app/_components/post-visualizer.tsx
@@ -353,18 +353,28 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                   >
                     <Image
                       alt=""
-                      className="post-thumb object-contain"
+                      className="rounded-none object-contain"
                       fill
                       sizes={IMAGE_SIZES}
                       src={post.image}
                       unoptimized
+                    />
+                    {/* Same from-background dissolve as the pinned chrome —
+                        left fade is wider so overlapping text stays readable. */}
+                    <span
+                      aria-hidden="true"
+                      className="pointer-events-none absolute inset-y-0 left-0 w-[42%] bg-linear-to-r from-background to-transparent"
+                    />
+                    <span
+                      aria-hidden="true"
+                      className="pointer-events-none absolute inset-y-0 right-0 w-[24%] bg-linear-to-l from-background to-transparent"
                     />
                   </Link>
                 ) : null}
 
                 <div
                   className={`pointer-events-none relative z-10 flex min-w-0 flex-col gap-y-0.5 ${
-                    post.image ? "pr-16 sm:pr-[4.75rem]" : ""
+                    post.image ? "pr-8 sm:pr-10" : ""
                   }`}
                 >
                 {/* Pins just below the Writing bar so the title comes to rest in

--- a/app/_components/post-visualizer.tsx
+++ b/app/_components/post-visualizer.tsx
@@ -18,13 +18,15 @@ interface PostsVisualizerProps {
   posts: SubstackPost[];
 }
 
-const IMAGE_SIZES = "(max-width: 768px) 92vw, 700px";
+const IMAGE_SIZES = "(max-width: 640px) 96px, 108px";
 
 /** How many titles back still count as "just passed" for the exit animation. */
 const TITLE_HISTORY = 4;
 
-/** Where a title comes to rest — just under the Writing bar, not behind it. */
-const TITLE_OFFSET = 104;
+/** Where a title comes to rest — just under the Writing bar, not behind it.
+ *  Titles no longer carry their own pt-4, so this sits a little lower than the
+ *  old 104px offset to keep the same clearance under the bar. */
+const TITLE_OFFSET = 120;
 
 interface TimelineMilestone {
   date: string;
@@ -330,20 +332,21 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
             >
               <span
                 aria-hidden="true"
-                className={`relative z-10 mx-auto mt-7 size-2 rounded-full border transition-[background-color,border-color,transform] duration-150 ease-out motion-reduce:transition-none ${
+                className={`relative z-10 mx-auto mt-6 size-2 rounded-full border transition-[background-color,border-color,transform] duration-150 ease-out motion-reduce:transition-none ${
                   isSelected
                     ? "scale-125 border-accent bg-accent"
                     : "border-border bg-background"
                 }`}
               />
               {/* min-w-0: grid items default to min-width:auto, which blocks the
-                  title's truncate from ever shrinking below its content width. */}
-              <div className="min-h-20 min-w-0">
+                  title's truncate from ever shrinking below its content width.
+                  Three text rows on the left, thumbnail spanning them on the right. */}
+              <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto_auto_auto] gap-x-3 gap-y-0.5 pb-6 pt-4">
                 {/* Pins just below the Writing bar so the title comes to rest in
                     that slot instead of sliding behind it. The shrink/slide sits
                     on an inner node — PinnedShell owns transform on the shell. */}
                 <PinnedShell
-                  className="relative z-30"
+                  className="relative z-30 col-start-1 row-start-1 min-w-0"
                   offset={TITLE_OFFSET}
                   releaseAfter={rowSpan || undefined}
                 >
@@ -365,7 +368,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                 >
                 <Link
                   aria-current={isSelected ? "true" : undefined}
-                  className={`flex min-h-11 min-w-0 items-center pb-1.5 pt-4 text-[1.05rem] leading-snug tracking-[-0.015em] transition-colors duration-150 motion-reduce:transition-none ${
+                  className={`block min-w-0 truncate text-[1.05rem] leading-snug tracking-[-0.015em] transition-colors duration-150 motion-reduce:transition-none ${
                     isSelected
                       ? "font-bold text-foreground"
                       : "font-normal text-muted/65 hover:text-foreground"
@@ -381,16 +384,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                   rel={post.slug ? undefined : "noopener noreferrer"}
                   target={post.slug ? undefined : "_blank"}
                 >
-                  <span className="flex min-w-0 items-baseline">
-                    <span className="truncate">{post.title}</span>
-                    <span
-                      className={`ml-2 shrink-0 whitespace-nowrap text-sm font-normal tracking-normal ${
-                        isSelected ? "text-muted/70" : "text-muted/45"
-                      }`}
-                    >
-                      • {formatPostDate(post.pubDate)}
-                    </span>
-                  </span>
+                  {post.title}
                 </Link>
                 </div>
                 </PinnedShell>
@@ -401,7 +395,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                   // a second one would announce the same destination twice.
                   <Link
                     aria-hidden="true"
-                    className={`mb-6 block max-w-prose text-[0.9rem] leading-relaxed transition-colors duration-150 motion-reduce:transition-none ${
+                    className={`col-start-1 row-start-2 truncate text-[0.9rem] leading-relaxed transition-colors duration-150 motion-reduce:transition-none ${
                       isSelected ? "text-muted/75" : "text-muted/45"
                     }`}
                     href={getPostHref(post)}
@@ -413,10 +407,25 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                   </Link>
                 ) : null}
 
+                <Link
+                  aria-hidden="true"
+                  className={`col-start-1 row-start-3 text-sm tracking-normal transition-colors duration-150 motion-reduce:transition-none ${
+                    isSelected ? "text-muted/70" : "text-muted/45"
+                  }`}
+                  href={getPostHref(post)}
+                  rel={post.slug ? undefined : "noopener noreferrer"}
+                  tabIndex={-1}
+                  target={post.slug ? undefined : "_blank"}
+                >
+                  <time dateTime={post.pubDate}>
+                    {formatPostDate(post.pubDate)}
+                  </time>
+                </Link>
+
                 {post.image ? (
                   <Link
                     aria-hidden="true"
-                    className="mb-8 block overflow-hidden rounded-xl border border-border bg-surface shadow-lg"
+                    className="relative col-start-2 row-span-3 row-start-1 w-24 self-stretch overflow-hidden border border-border bg-surface sm:w-[6.75rem]"
                     href={getPostHref(post)}
                     rel={post.slug ? undefined : "noopener noreferrer"}
                     tabIndex={-1}
@@ -424,12 +433,11 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                   >
                     <Image
                       alt=""
-                      className="h-[clamp(9rem,34vw,13rem)] w-full object-cover"
-                      height={400}
+                      className="object-cover"
+                      fill
                       sizes={IMAGE_SIZES}
                       src={post.image}
                       unoptimized
-                      width={700}
                     />
                   </Link>
                 ) : null}

--- a/app/_components/post-visualizer.tsx
+++ b/app/_components/post-visualizer.tsx
@@ -18,7 +18,7 @@ interface PostsVisualizerProps {
   posts: SubstackPost[];
 }
 
-const IMAGE_SIZES = "(max-width: 640px) 96px, 108px";
+const IMAGE_SIZES = "(max-width: 640px) 140px, 180px";
 
 /** How many titles back still count as "just passed" for the exit animation. */
 const TITLE_HISTORY = 4;
@@ -338,15 +338,40 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                     : "border-border bg-background"
                 }`}
               />
-              {/* min-w-0: grid items default to min-width:auto, which blocks the
-                  title's truncate from ever shrinking below its content width.
-                  Three text rows on the left, thumbnail spanning them on the right. */}
-              <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto_auto_auto] gap-x-3 gap-y-0.5 pb-6 pt-4">
+              {/* Three text rows on the left; the thumbnail sits behind the
+                  right edge so a long title can run a little over the photo.
+                  min-w-0 lets truncate shrink instead of blowing out the grid. */}
+              <div className="relative min-w-0 pb-6 pt-4">
+                {post.image ? (
+                  <Link
+                    aria-hidden="true"
+                    className="absolute top-4 bottom-6 right-0 z-0 aspect-[3/2]"
+                    href={getPostHref(post)}
+                    rel={post.slug ? undefined : "noopener noreferrer"}
+                    tabIndex={-1}
+                    target={post.slug ? undefined : "_blank"}
+                  >
+                    <Image
+                      alt=""
+                      className="post-thumb object-contain"
+                      fill
+                      sizes={IMAGE_SIZES}
+                      src={post.image}
+                      unoptimized
+                    />
+                  </Link>
+                ) : null}
+
+                <div
+                  className={`pointer-events-none relative z-10 flex min-w-0 flex-col gap-y-0.5 ${
+                    post.image ? "pr-16 sm:pr-[4.75rem]" : ""
+                  }`}
+                >
                 {/* Pins just below the Writing bar so the title comes to rest in
                     that slot instead of sliding behind it. The shrink/slide sits
                     on an inner node — PinnedShell owns transform on the shell. */}
                 <PinnedShell
-                  className="relative z-30 col-start-1 row-start-1 min-w-0"
+                  className="pointer-events-auto relative z-30 min-w-0"
                   offset={TITLE_OFFSET}
                   releaseAfter={rowSpan || undefined}
                 >
@@ -395,7 +420,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                   // a second one would announce the same destination twice.
                   <Link
                     aria-hidden="true"
-                    className={`col-start-1 row-start-2 truncate text-[0.9rem] leading-relaxed transition-colors duration-150 motion-reduce:transition-none ${
+                    className={`pointer-events-auto truncate text-[0.9rem] leading-relaxed transition-colors duration-150 motion-reduce:transition-none ${
                       isSelected ? "text-muted/75" : "text-muted/45"
                     }`}
                     href={getPostHref(post)}
@@ -409,7 +434,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
 
                 <Link
                   aria-hidden="true"
-                  className={`col-start-1 row-start-3 text-sm tracking-normal transition-colors duration-150 motion-reduce:transition-none ${
+                  className={`pointer-events-auto text-sm tracking-normal transition-colors duration-150 motion-reduce:transition-none ${
                     isSelected ? "text-muted/70" : "text-muted/45"
                   }`}
                   href={getPostHref(post)}
@@ -421,26 +446,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                     {formatPostDate(post.pubDate)}
                   </time>
                 </Link>
-
-                {post.image ? (
-                  <Link
-                    aria-hidden="true"
-                    className="relative col-start-2 row-span-3 row-start-1 w-24 self-stretch overflow-hidden border border-border bg-surface sm:w-[6.75rem]"
-                    href={getPostHref(post)}
-                    rel={post.slug ? undefined : "noopener noreferrer"}
-                    tabIndex={-1}
-                    target={post.slug ? undefined : "_blank"}
-                  >
-                    <Image
-                      alt=""
-                      className="object-cover"
-                      fill
-                      sizes={IMAGE_SIZES}
-                      src={post.image}
-                      unoptimized
-                    />
-                  </Link>
-                ) : null}
+                </div>
               </div>
             </li>
           );

--- a/app/globals.css
+++ b/app/globals.css
@@ -96,6 +96,25 @@ body {
   }
 }
 
+/* Writing thumbnails: dissolve into the page on both sides so title text can
+   sit over the left edge without fighting the photo for contrast. */
+.post-thumb {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    #000 1.85rem,
+    #000 calc(100% - 1.35rem),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    #000 1.85rem,
+    #000 calc(100% - 1.35rem),
+    transparent 100%
+  );
+}
+
 ::selection {
   background-color: var(--accent);
   color: white;

--- a/app/globals.css
+++ b/app/globals.css
@@ -96,25 +96,6 @@ body {
   }
 }
 
-/* Writing thumbnails: dissolve into the page on both sides so title text can
-   sit over the left edge without fighting the photo for contrast. */
-.post-thumb {
-  -webkit-mask-image: linear-gradient(
-    to right,
-    transparent 0%,
-    #000 1.85rem,
-    #000 calc(100% - 1.35rem),
-    transparent 100%
-  );
-  mask-image: linear-gradient(
-    to right,
-    transparent 0%,
-    #000 1.85rem,
-    #000 calc(100% - 1.35rem),
-    transparent 100%
-  );
-}
-
 ::selection {
   background-color: var(--accent);
   color: white;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The large rounded cover images on the Writing timeline felt out of step with the rest of the page.

Each post is now three rows on the left — title, description, date — with the cover on the right, kept at its 3:2 ratio and sized to those rows. The photo sits a little under the text. Left and right edges dissolve into the page colour (the same `from-background` fade as the pinned chrome), so overlapping type stays readable and there is no hard card, border, or rounded crop.

![Writing list in light mode](https://cursor.com/artifacts/c/art-9645441d-bd31-422d-b1d6-ec0786bc2aee)
![Writing list in dark mode](https://cursor.com/artifacts/c/art-ca857a0e-d61b-47f5-bb1b-5cf767c8afaa)
![Close-up of text overlapping a faded thumbnail](https://cursor.com/artifacts/c/art-b29d7b3d-5976-4098-9dc1-03d254ed9411)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dfa99bf-61d1-4fac-93b7-399a3ed2212a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dfa99bf-61d1-4fac-93b7-399a3ed2212a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

