### PR TITLE
Stagger place circles, blue wishlist ink, and a wide tap target

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The homepage also draws a rough world map from the same record. Day counts
 stay in storage; the map keeps the whole world in view and circles regions
 by hand — most of the time, casual, and a couple still ahead — rather than
 pins or numbers. San Francisco and Canada sit on the map as places I'd like
-to go; they are not part of the location store.
+to go, in a complementary blue; they are not part of the location store.
 Location reads expire
 within 60 seconds; weather is cached separately by rounded coordinates for
 several minutes. If the store is unavailable or contains an invalid value,

--- a/app/_components/places-map-frame.tsx
+++ b/app/_components/places-map-frame.tsx
@@ -6,7 +6,6 @@ import {
   MAP_PADDING,
   MAP_WIDTH,
   continentPaths,
-  wantedCircles,
   type PlaceMarkKind,
 } from "@/lib/world-map";
 import { cacheLife } from "next/cache";
@@ -15,7 +14,6 @@ const VIEW_WIDTH = MAP_WIDTH + MAP_PADDING * 2;
 const VIEW_HEIGHT = MAP_HEIGHT + MAP_PADDING * 2;
 
 function CircleSwatch({ kind }: { kind: PlaceMarkKind }) {
-  const dashed = kind === "wanted";
   return (
     <svg
       aria-hidden="true"
@@ -23,7 +21,7 @@ function CircleSwatch({ kind }: { kind: PlaceMarkKind }) {
         kind === "habitual"
           ? "text-accent"
           : kind === "wanted"
-            ? "text-accent-light"
+            ? "text-wish"
             : "text-muted/70"
       }`}
       viewBox="0 0 16 16"
@@ -38,7 +36,6 @@ function CircleSwatch({ kind }: { kind: PlaceMarkKind }) {
         }
         fill="none"
         stroke="currentColor"
-        strokeDasharray={dashed ? "1.6 1.15" : undefined}
         strokeLinecap="round"
         strokeWidth={kind === "habitual" ? 1.55 : 1.2}
       />
@@ -57,7 +54,6 @@ async function CachedVisitedCircles() {
 
 export function PlacesMap() {
   const continents = continentPaths();
-  const wanted = wantedCircles();
 
   return (
     <section
@@ -140,22 +136,6 @@ export function PlacesMap() {
                 key={continent.name}
                 strokeLinejoin="round"
                 strokeWidth="1.35"
-              />
-            ))}
-          </g>
-
-          <g className="text-accent-light" filter="url(#places-map-circles)">
-            {wanted.map((circle) => (
-              <path
-                d={circle.path}
-                fill="none"
-                key={circle.label}
-                pathLength={1}
-                stroke="currentColor"
-                strokeDasharray="0.2 0.09"
-                strokeLinecap="round"
-                strokeOpacity={0.9}
-                strokeWidth={circle.width}
               />
             ))}
           </g>

--- a/app/_components/places-map.tsx
+++ b/app/_components/places-map.tsx
@@ -1,17 +1,55 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type PointerEvent } from "react";
 import type { VisitedPlace } from "@/server/location-data";
-import { MAP_WIDTH, zoneCircles } from "@/lib/world-map";
+import {
+  CIRCLE_DRAW_MS,
+  CIRCLE_STAGGER_MS,
+  MAP_HEIGHT,
+  MAP_PADDING,
+  MAP_WIDTH,
+  closestPlaceCircle,
+  drawOrder,
+  wantedCircles,
+  zoneCircles,
+  type ProjectedPoint,
+  type ZoneCircle,
+} from "@/lib/world-map";
+
+const VIEW_WIDTH = MAP_WIDTH + MAP_PADDING * 2;
+const VIEW_HEIGHT = MAP_HEIGHT + MAP_PADDING * 2;
 
 interface PlaceCirclesProps {
   places: VisitedPlace[];
 }
 
+function eventToSvgPoint(event: PointerEvent<Element>): ProjectedPoint | null {
+  const svg = event.currentTarget.closest("svg");
+  if (!(svg instanceof SVGSVGElement)) return null;
+
+  const ctm = svg.getScreenCTM();
+  if (!ctm) return null;
+
+  const point = svg.createSVGPoint();
+  point.x = event.clientX;
+  point.y = event.clientY;
+  const mapped = point.matrixTransform(ctm.inverse());
+  return { x: mapped.x, y: mapped.y };
+}
+
+function markClass(circle: ZoneCircle): string {
+  if (circle.kind === "habitual") return "text-accent";
+  if (circle.kind === "wanted") return "text-wish";
+  return "text-muted/70";
+}
+
 export default function PlaceCircles({ places }: PlaceCirclesProps) {
   const [activeLabel, setActiveLabel] = useState<string | null>(null);
   const [drawn, setDrawn] = useState(false);
-  const circles = useMemo(() => zoneCircles(places), [places]);
+  const circles = useMemo(
+    () => drawOrder([...wantedCircles(), ...zoneCircles(places)]),
+    [places]
+  );
   const active = circles.find((circle) => circle.label === activeLabel) ?? null;
 
   useEffect(() => {
@@ -40,50 +78,71 @@ export default function PlaceCircles({ places }: PlaceCirclesProps) {
     return () => observer.disconnect();
   }, []);
 
+  function activateClosest(event: PointerEvent<Element>, sticky: boolean) {
+    const point = eventToSvgPoint(event);
+    if (!point) return;
+
+    const hit = closestPlaceCircle(point, circles);
+    if (!hit) {
+      setActiveLabel(null);
+      return;
+    }
+
+    if (sticky) {
+      setActiveLabel((current) => (current === hit.label ? null : hit.label));
+      return;
+    }
+
+    setActiveLabel(hit.label);
+  }
+
   return (
     <g filter="url(#places-map-circles)">
+      <rect
+        fill="transparent"
+        height={VIEW_HEIGHT}
+        onPointerDown={(event) => {
+          if (event.pointerType === "mouse") return;
+          activateClosest(event, true);
+        }}
+        onPointerLeave={(event) => {
+          if (event.pointerType === "mouse") setActiveLabel(null);
+        }}
+        onPointerMove={(event) => {
+          if (event.pointerType !== "mouse") return;
+          activateClosest(event, false);
+        }}
+        width={VIEW_WIDTH}
+        x={-MAP_PADDING}
+        y={-MAP_PADDING}
+      />
+
       {circles.map((circle, index) => {
         const isActive = active?.label === circle.label;
-        const habitualMark = circle.kind === "habitual";
         return (
-          <g
-            className={
-              habitualMark
-                ? "cursor-pointer text-accent"
-                : "cursor-pointer text-muted/70"
-            }
+          <path
+            className={markClass(circle)}
+            d={circle.path}
+            fill="none"
             key={`${circle.label}-${circle.kind}`}
-            onClick={() =>
-              setActiveLabel((current) =>
-                current === circle.label ? null : circle.label
-              )
+            pathLength={1}
+            pointerEvents="none"
+            stroke="currentColor"
+            strokeDasharray="1 1"
+            strokeDashoffset={drawn ? 0 : 1}
+            strokeLinecap="round"
+            strokeOpacity={
+              isActive ? 0.95 : circle.kind === "casual" ? 0.62 : 0.88
             }
-            onMouseEnter={() => setActiveLabel(circle.label)}
-            onMouseLeave={() =>
-              setActiveLabel((current) =>
-                current === circle.label ? null : current
-              )
-            }
-          >
-            <path
-              d={circle.path}
-              fill="none"
-              pathLength={1}
-              stroke="currentColor"
-              strokeDasharray="1 1"
-              strokeDashoffset={drawn ? 0 : 1}
-              strokeLinecap="round"
-              strokeOpacity={isActive ? 0.95 : habitualMark ? 0.88 : 0.62}
-              strokeWidth={circle.width}
-              style={{
-                transition: drawn
-                  ? `stroke-dashoffset 640ms cubic-bezier(0.3,0.7,0.4,1) ${
-                      index * 90
-                    }ms`
-                  : "none",
-              }}
-            />
-          </g>
+            strokeWidth={circle.width}
+            style={{
+              transition: drawn
+                ? `stroke-dashoffset ${CIRCLE_DRAW_MS}ms cubic-bezier(0.3,0.7,0.4,1) ${
+                    index * CIRCLE_STAGGER_MS
+                  }ms`
+                : "none",
+            }}
+          />
         );
       })}
 
@@ -91,6 +150,7 @@ export default function PlaceCircles({ places }: PlaceCirclesProps) {
         <text
           className="fill-foreground"
           fontSize="14"
+          pointerEvents="none"
           textAnchor={active.x > MAP_WIDTH * 0.62 ? "end" : "start"}
           x={active.x + (active.x > MAP_WIDTH * 0.62 ? -22 : 22)}
           y={active.y - 26}

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,6 +15,7 @@
   --color-muted: var(--muted);
   --color-accent: var(--accent);
   --color-accent-light: var(--accent-light);
+  --color-wish: var(--wish);
   --color-border: var(--border);
 }
 
@@ -26,6 +27,7 @@
   --muted: #57534E;
   --accent: #EA580C;
   --accent-light: #FDBA74;
+  --wish: #2E6F8A;
   --border: #E6E2D8;
 }
 
@@ -38,6 +40,7 @@
     --muted: #D6D6DD;
     --accent: #EA580C;
     --accent-light: #FDBA74;
+    --wish: #7EB6C9;
     --border: #33302B;
   }
 }

--- a/lib/world-map.test.ts
+++ b/lib/world-map.test.ts
@@ -5,8 +5,10 @@ import {
   MAP_HEIGHT,
   MAP_WIDTH,
   WANTED_PLACES,
+  closestPlaceCircle,
   continentPaths,
   continentRing,
+  drawOrder,
   projectLocation,
   stayKind,
   wantedCircles,
@@ -114,8 +116,8 @@ test("circles San Francisco and Canada as places still ahead", () => {
   assert.ok(canada);
   assert.equal(sanFrancisco.kind, "wanted");
   assert.equal(canada.kind, "wanted");
-  assert.ok(sanFrancisco.dashed);
-  assert.ok(canada.dashed);
+  assert.ok(sanFrancisco.hitRadius >= 36);
+  assert.ok(canada.hitRadius >= 36);
   assert.ok(sanFrancisco.x < canada.x);
   assert.ok(sanFrancisco.y > canada.y);
   assert.ok(
@@ -123,4 +125,29 @@ test("circles San Francisco and Canada as places still ahead", () => {
     "San Francisco and Canada should not read as one North American scribble"
   );
   assert.ok((canada.path.match(/Q /g) ?? []).length >= 12);
+});
+
+test("picks the closest circle inside a broad hit zone", () => {
+  const [lisbonMark, parisMark] = zoneCircles([lisbon, paris]);
+  assert.ok(lisbonMark);
+  assert.ok(parisMark);
+
+  const nearerLisbon = closestPlaceCircle(
+    { x: lisbonMark.x + 10, y: lisbonMark.y + 8 },
+    [lisbonMark, parisMark]
+  );
+  assert.equal(nearerLisbon?.label, "Lisbon");
+
+  const miss = closestPlaceCircle(
+    { x: lisbonMark.x + 200, y: lisbonMark.y + 200 },
+    [lisbonMark, parisMark]
+  );
+  assert.equal(miss, null);
+});
+
+test("draws circles west to east so they appear one by one", () => {
+  const ordered = drawOrder([...wantedCircles(), ...zoneCircles([lisbon, paris])]);
+  for (let index = 1; index < ordered.length; index += 1) {
+    assert.ok(ordered[index].x >= ordered[index - 1].x);
+  }
 });

--- a/lib/world-map.ts
+++ b/lib/world-map.ts
@@ -413,13 +413,39 @@ function buildCirclePath(
 }
 
 export interface ZoneCircle {
-  dashed: boolean;
+  hitRadius: number;
   kind: PlaceMarkKind;
   label: string;
   path: string;
   width: number;
   x: number;
   y: number;
+}
+
+export const CIRCLE_DRAW_MS = 640;
+export const CIRCLE_STAGGER_MS = 580;
+
+export function closestPlaceCircle(
+  point: ProjectedPoint,
+  circles: readonly ZoneCircle[],
+  extra = 0
+): ZoneCircle | null {
+  let best: ZoneCircle | null = null;
+  let bestDistance = Infinity;
+
+  for (const circle of circles) {
+    const distance = Math.hypot(circle.x - point.x, circle.y - point.y);
+    if (distance <= circle.hitRadius + extra && distance < bestDistance) {
+      best = circle;
+      bestDistance = distance;
+    }
+  }
+
+  return best;
+}
+
+export function drawOrder(circles: readonly ZoneCircle[]): ZoneCircle[] {
+  return [...circles].sort((left, right) => left.x - right.x || left.y - right.y);
 }
 
 const ZONE_STEP_DEGREES = 8;
@@ -446,7 +472,7 @@ export function zoneCircles(places: readonly VisitedPlace[]): ZoneCircle[] {
     const turns = kind === "habitual" ? 1.38 + random() * 0.2 : 1.14 + random() * 0.14;
 
     return {
-      dashed: false,
+      hitRadius: Math.max(radius * 1.35, 36),
       kind,
       label: place.city,
       path: buildCirclePath(origin, radius, radius * stretch, random, turns),
@@ -466,10 +492,10 @@ export function wantedCircles(
     const radius = place.span === "region" ? 36 : 24;
     const stretch = 0.74 + random() * 0.18;
     // Unfinished on purpose — a place not yet gone around.
-    const turns = 0.86 + random() * 0.12;
+    const turns = 1.08 + random() * 0.12;
 
     return {
-      dashed: true,
+      hitRadius: Math.max(radius * 1.35, 36),
       kind: "wanted",
       label: place.name,
       path: buildCirclePath(origin, radius, radius * stretch, random, turns),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Builds on the prerendered Places map.

Circles now draw **one by one**, west to east — each loop almost finishes before the next starts, instead of all fading in together.

**I'd like to go** is no longer dotted. It uses a complementary steel blue (`#2E6F8A` on cream, a lighter blue in dark mode) so it sits next to the orange accent without competing.

The thin ink is hard to hit on a phone. The whole map is a hit surface: a tap or hover picks the **closest** circle inside a broad zone (at least 36 map units). Tap again to dismiss; a tap on empty ocean clears the name. Mouse still follows as you move.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffcb9-23f4-7f4c-b8c1-1d95c0d63c25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffcb9-23f4-7f4c-b8c1-1d95c0d63c25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

