### PR TITLE
Replay place-circle drawing when the map re-enters view

### DIFF
--- a/app/_components/places-map.tsx
+++ b/app/_components/places-map.tsx
@@ -67,15 +67,28 @@ export default function PlaceCircles({ places }: PlaceCirclesProps) {
       return;
     }
 
-    const observer = new IntersectionObserver(
+    // Two observers, far enough apart that a later pass can redraw without
+    // catching the loops erasing themselves on screen.
+    const drawObserver = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) setDrawn(true);
       },
       { rootMargin: "0px 0px -15% 0px", threshold: 0.35 }
     );
 
-    observer.observe(section);
-    return () => observer.disconnect();
+    const armObserver = new IntersectionObserver(
+      (entries) => {
+        if (entries.every((entry) => !entry.isIntersecting)) setDrawn(false);
+      },
+      { threshold: 0 }
+    );
+
+    drawObserver.observe(section);
+    armObserver.observe(section);
+    return () => {
+      drawObserver.disconnect();
+      armObserver.disconnect();
+    };
   }, []);
 
   function activateClosest(event: PointerEvent<Element>, sticky: boolean) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Scroll the Places map out of view, then back in: the circles should draw again, one by one, west to east.

The highlighter already does this with two observers. The map now does the same:

- A draw observer turns the animation on when the map is in the lower part of the viewport.
- A re-arm observer turns it off only after the map is fully off screen, so the erase is instant and not visible.

Reduced-motion still skips the observers and shows every circle at once.

No store, cache, or payload changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffcb9-23f4-7f4c-b8c1-1d95c0d63c25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffcb9-23f4-7f4c-b8c1-1d95c0d63c25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

