### PR TITLE
Show blog artwork as postage stamps

### DIFF
--- a/app/_components/highlighter-text.tsx
+++ b/app/_components/highlighter-text.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { createRandom } from "@/lib/seeded-random";
 
 interface HighlighterTextProps {
   /** The text the marker sweeps over. Plain text — the range maths reads lines. */
@@ -27,28 +28,6 @@ interface MarkerStroke {
   duration: number;
   path: string;
   width: number;
-}
-
-/**
- * Hash a string into a small deterministic PRNG (mulberry32 over an FNV-1a seed).
- * Every stroke shape comes out of this, so the marks look hand-made but never
- * change under the reader — including between measurements.
- */
-function createRandom(seed: string): () => number {
-  let hash = 2166136261;
-
-  for (let index = 0; index < seed.length; index += 1) {
-    hash ^= seed.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
-  }
-
-  return () => {
-    hash = (hash + 0x6d2b79f5) | 0;
-    let value = hash;
-    value = Math.imul(value ^ (value >>> 15), value | 1);
-    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
-    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
-  };
 }
 
 interface Point {

--- a/app/_components/mdx-components-list.tsx
+++ b/app/_components/mdx-components-list.tsx
@@ -1,6 +1,6 @@
 import { ComponentPropsWithoutRef } from "react";
-import Image from "next/image";
 import Link from "next/link";
+import { PostStamp } from "./post-stamp";
 import { Tweet } from "./tweet";
 
 export const mdxComponents = {
@@ -99,22 +99,18 @@ export const mdxComponents = {
       </Link>
     );
   },
-  img: ({ src, alt, ...props }: ComponentPropsWithoutRef<"img">) => {
+  img: ({ src, alt }: ComponentPropsWithoutRef<"img">) => {
     if (!src || typeof src !== "string") return null;
 
-    const isExternal = src.startsWith("http");
-
     return (
-      <span className="block relative w-full bg-surface my-4 overflow-hidden rounded-lg border border-border aspect-3/2 scale-105">
-          <Image
-            src={src}
-            alt={typeof alt === "string" ? alt : ""}
-            fill
-            className="object-contain"
-            sizes="(max-width: 768px) 90vw, 700px"
-            loading="lazy"
-            unoptimized={isExternal}
-          />
+      <span className="my-6 block overflow-visible py-2">
+        <PostStamp
+          alt={typeof alt === "string" ? alt : ""}
+          seed={src}
+          sizes="(max-width: 768px) 90vw, 700px"
+          src={src}
+          variant="feature"
+        />
       </span>
     );
   },

--- a/app/_components/playable-stamp.tsx
+++ b/app/_components/playable-stamp.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import {
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  useRef,
+  useState,
+} from "react";
+
+export interface StampOffset {
+  x: number;
+  y: number;
+}
+
+interface PlayableStampProps {
+  children: ReactNode;
+  className?: string;
+  offset: StampOffset;
+  onOffset: (offset: StampOffset) => void;
+  /**
+   * Title stamps sit in the scrolling list. If the first movement is mostly
+   * vertical, leave the gesture to the page so a drag does not steal scroll.
+   */
+  allowVerticalScroll?: boolean;
+}
+
+const DRAG_THRESHOLD = 8;
+
+/**
+ * Pointer drag for a stamp — mouse, touch, and pen. A tap still reaches the
+ * link inside; a drag does not navigate.
+ */
+export function PlayableStamp({
+  children,
+  className,
+  offset,
+  onOffset,
+  allowVerticalScroll = false,
+}: PlayableStampProps) {
+  const hostRef = useRef<HTMLSpanElement>(null);
+  const dragRef = useRef<{
+    blocked: boolean;
+    moved: boolean;
+    originX: number;
+    originY: number;
+    pointerId: number;
+    startX: number;
+    startY: number;
+  } | null>(null);
+  const didDragRef = useRef(false);
+  const [dragging, setDragging] = useState(false);
+
+  const endDrag = (event: ReactPointerEvent<HTMLSpanElement>) => {
+    const drag = dragRef.current;
+    if (!drag || event.pointerId !== drag.pointerId) return;
+
+    if (drag.moved) {
+      didDragRef.current = true;
+      event.preventDefault();
+    }
+
+    if (hostRef.current?.hasPointerCapture(event.pointerId)) {
+      hostRef.current.releasePointerCapture(event.pointerId);
+    }
+
+    dragRef.current = null;
+    setDragging(false);
+  };
+
+  return (
+    <span
+      ref={hostRef}
+      className={`stamp-play relative block ${className ?? ""}`}
+      data-allow-scroll={allowVerticalScroll ? "true" : undefined}
+      data-dragging={dragging ? "true" : undefined}
+      onClickCapture={(event) => {
+        if (!didDragRef.current) return;
+        event.preventDefault();
+        event.stopPropagation();
+        didDragRef.current = false;
+      }}
+      onPointerCancel={endDrag}
+      onPointerDown={(event) => {
+        if (event.button !== 0) return;
+        didDragRef.current = false;
+        dragRef.current = {
+          blocked: false,
+          moved: false,
+          originX: offset.x,
+          originY: offset.y,
+          pointerId: event.pointerId,
+          startX: event.clientX,
+          startY: event.clientY,
+        };
+      }}
+      onPointerMove={(event) => {
+        const drag = dragRef.current;
+        if (!drag || event.pointerId !== drag.pointerId || drag.blocked) return;
+
+        const dx = event.clientX - drag.startX;
+        const dy = event.clientY - drag.startY;
+
+        if (!drag.moved) {
+          if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
+          if (allowVerticalScroll && Math.abs(dy) > Math.abs(dx) * 1.15) {
+            drag.blocked = true;
+            dragRef.current = null;
+            return;
+          }
+
+          drag.moved = true;
+          setDragging(true);
+          hostRef.current?.setPointerCapture(event.pointerId);
+        }
+
+        event.preventDefault();
+        onOffset({ x: drag.originX + dx, y: drag.originY + dy });
+      }}
+      onPointerUp={endDrag}
+      style={{
+        transform: `translate(${offset.x}px, ${offset.y}px)`,
+        zIndex: dragging ? 50 : undefined,
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/app/_components/playable-stamp.tsx
+++ b/app/_components/playable-stamp.tsx
@@ -70,7 +70,7 @@ export function PlayableStamp({
   return (
     <span
       ref={hostRef}
-      className={`stamp-play relative block ${className ?? ""}`}
+      className={`stamp-play relative block w-full ${className ?? ""}`}
       data-allow-scroll={allowVerticalScroll ? "true" : undefined}
       data-dragging={dragging ? "true" : undefined}
       onClickCapture={(event) => {

--- a/app/_components/post-stamp.tsx
+++ b/app/_components/post-stamp.tsx
@@ -1,0 +1,101 @@
+import Image from "next/image";
+import Link from "next/link";
+import { getStampPose, type StampAlign } from "@/lib/stamp-pose";
+
+interface PostStampProps {
+  src: string;
+  seed: string;
+  alt?: string;
+  href?: string;
+  sizes?: string;
+  variant?: "collectible" | "feature";
+  /** Hide the link from assistive tech when a title already points here. */
+  decorative?: boolean;
+  external?: boolean;
+}
+
+const ALIGN_CLASS: Record<StampAlign, string> = {
+  start: "justify-start",
+  center: "justify-center",
+  end: "justify-end",
+};
+
+export function PostStamp({
+  src,
+  seed,
+  alt = "",
+  href,
+  sizes = "(max-width: 768px) 92vw, 700px",
+  variant = "collectible",
+  decorative = false,
+  external = false,
+}: PostStampProps) {
+  const pose = getStampPose(seed, variant);
+  const isExternal = src.startsWith("http");
+  const collectible = variant === "collectible";
+
+  const picture = (
+    <span
+      className="stamp-paper block"
+      style={{
+        ["--stamp-pitch" as string]: `${pose.pitch}px`,
+        transform: `rotate(${pose.rotate}deg) translate(${pose.shiftX}px, ${pose.shiftY}px)`,
+      }}
+    >
+      <span
+        className={
+          collectible
+            ? "stamp-window relative block aspect-3/2 overflow-hidden"
+            : "stamp-window relative block overflow-hidden"
+        }
+      >
+        {collectible ? (
+          <Image
+            alt={alt}
+            className="object-cover"
+            fill
+            sizes={sizes}
+            src={src}
+            unoptimized={isExternal}
+          />
+        ) : (
+          <Image
+            alt={alt}
+            className="h-auto w-full"
+            height={400}
+            sizes={sizes}
+            src={src}
+            unoptimized={isExternal}
+            width={700}
+          />
+        )}
+      </span>
+    </span>
+  );
+
+  const body = href ? (
+    <Link
+      aria-hidden={decorative ? true : undefined}
+      className="stamp-shadow block w-full"
+      href={href}
+      rel={external ? "noopener noreferrer" : undefined}
+      tabIndex={decorative ? -1 : undefined}
+      target={external ? "_blank" : undefined}
+    >
+      {picture}
+    </Link>
+  ) : (
+    <span className="stamp-shadow block w-full">{picture}</span>
+  );
+
+  return (
+    <span
+      className={`flex ${ALIGN_CLASS[pose.align]}`}
+      style={{ width: "100%" }}
+    >
+      <span className="block" style={{ width: `${pose.width * 100}%` }}>
+        {body}
+      </span>
+    </span>
+  );
+}

--- a/app/_components/post-stamp.tsx
+++ b/app/_components/post-stamp.tsx
@@ -8,7 +8,7 @@ interface PostStampProps {
   alt?: string;
   href?: string;
   sizes?: string;
-  variant?: "collectible" | "feature";
+  variant?: "collectible" | "feature" | "album";
   /** Hide the link from assistive tech when a title already points here. */
   decorative?: boolean;
   external?: boolean;
@@ -30,26 +30,31 @@ export function PostStamp({
   decorative = false,
   external = false,
 }: PostStampProps) {
-  const pose = getStampPose(seed, variant);
+  const pose = getStampPose(seed, variant === "album" ? "collectible" : variant);
   const isExternal = src.startsWith("http");
+  const album = variant === "album";
   const collectible = variant === "collectible";
 
   const picture = (
     <span
-      className="stamp-paper block"
+      className={`stamp-paper block ${album ? "stamp-paper-album" : ""}`}
       style={{
-        ["--stamp-pitch" as string]: `${pose.pitch}px`,
-        transform: `rotate(${pose.rotate}deg) translate(${pose.shiftX}px, ${pose.shiftY}px)`,
+        ["--stamp-pitch" as string]: album
+          ? `${Math.max(6.5, pose.pitch * 0.58)}px`
+          : `${pose.pitch}px`,
+        transform: album
+          ? undefined
+          : `rotate(${pose.rotate}deg) translate(${pose.shiftX}px, ${pose.shiftY}px)`,
       }}
     >
       <span
         className={
-          collectible
+          collectible || album
             ? "stamp-window relative block aspect-3/2 overflow-hidden"
             : "stamp-window relative block overflow-hidden"
         }
       >
-        {collectible ? (
+        {collectible || album ? (
           <Image
             alt={alt}
             className="object-cover"
@@ -87,6 +92,10 @@ export function PostStamp({
   ) : (
     <span className="stamp-shadow block w-full">{picture}</span>
   );
+
+  if (album) {
+    return body;
+  }
 
   return (
     <span

--- a/app/_components/post-stamp.tsx
+++ b/app/_components/post-stamp.tsx
@@ -37,7 +37,7 @@ export function PostStamp({
 
   const picture = (
     <span
-      className={`stamp-paper block ${album ? "stamp-paper-album" : ""}`}
+      className={`stamp-paper block w-full ${album ? "stamp-paper-album" : ""}`}
       style={{
         ["--stamp-pitch" as string]: album
           ? `${Math.max(6.5, pose.pitch * 0.58)}px`
@@ -50,7 +50,7 @@ export function PostStamp({
       <span
         className={
           collectible || album
-            ? "stamp-window relative block aspect-3/2 overflow-hidden"
+            ? "stamp-window relative block aspect-3/2 w-full overflow-hidden"
             : "stamp-window relative block overflow-hidden"
         }
       >

--- a/app/_components/post-visualizer.tsx
+++ b/app/_components/post-visualizer.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import {
   type MouseEvent,
+  useCallback,
   useEffect,
   useMemo,
   useReducer,
@@ -11,16 +12,20 @@ import {
 } from "react";
 import type { SubstackPost } from "@/types/substack-post";
 import { layoutStampAlbum } from "@/lib/stamp-album";
+import {
+  isStampCollected,
+  isTitleStampActive,
+} from "@/lib/stamp-visibility";
 import HighlighterText from "./highlighter-text";
 import { PinnedShell } from "./pinned-shell";
-import { PostStamp } from "./post-stamp";
+import type { StampOffset } from "./playable-stamp";
 import { StampAlbum } from "./stamp-album";
+import { TitleStamp } from "./title-stamp";
+import { useFadingPresence } from "./use-fading-presence";
 
 interface PostsVisualizerProps {
   posts: SubstackPost[];
 }
-
-const IMAGE_SIZES = "(max-width: 768px) 92vw, 700px";
 
 /** How many titles back still count as "just passed" for the exit animation. */
 const TITLE_HISTORY = 4;
@@ -128,17 +133,16 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
   );
   const sectionRef = useRef<HTMLElement>(null);
   const postRefs = useRef<Array<HTMLLIElement | null>>([]);
-  const stampRefs = useRef<Array<HTMLDivElement | null>>([]);
-  const collectLineRef = useRef<HTMLDivElement>(null);
+  const stampRefs = useRef<Array<HTMLSpanElement | null>>([]);
   const writingBarRef = useRef<HTMLDivElement>(null);
-  const collectedRef = useRef<boolean[]>([]);
   const originsRef = useRef<Map<string, DOMRect>>(new Map());
+  const albumRectsRef = useRef<Map<string, DOMRect>>(new Map());
   // Average row height, used to release each pinned title after about one row
   // so it hands the slot to the next one instead of staying put.
   const [rowSpan, setRowSpan] = useState(0);
-  const [collected, setCollected] = useState<boolean[]>([]);
   const [titleOffset, setTitleOffset] = useState(TITLE_OFFSET);
   const [trayWidth, setTrayWidth] = useState(0);
+  const [offsets, setOffsets] = useState<Record<string, StampOffset>>({});
 
   const sortedPosts = useMemo(
     () =>
@@ -169,9 +173,9 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
 
   useEffect(() => {
     dispatchSelection({ type: "reset" });
-    collectedRef.current = [];
     originsRef.current.clear();
-    setCollected([]);
+    albumRectsRef.current.clear();
+    setOffsets({});
   }, [posts]);
 
   useEffect(() => {
@@ -192,7 +196,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
       observer.disconnect();
       window.removeEventListener("resize", measureBar);
     };
-  }, [collected]);
+  }, [selection.currentIndex]);
 
   useEffect(() => {
     const measureRowSpan = () => {
@@ -233,34 +237,15 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
 
       dispatchSelection({ type: "select", index: nearestIndex });
 
-      // A stamp collects the first time it meets the Writing bar. The list
-      // slot stays put — collapsing it would yank the next stamp up into the
-      // line and collect the whole deck in one frame.
-      const line =
-        collectLineRef.current?.getBoundingClientRect().bottom ?? TITLE_OFFSET;
-      const previous = collectedRef.current;
-      const next = sortedPosts.map((post, index) => {
-        if (!post.image) return false;
-        const stamp = stampRefs.current[index];
-        if (!stamp) return previous[index] ?? false;
-
-        const top = stamp.getBoundingClientRect().top;
-        if (!(previous[index] ?? false)) {
-          originsRef.current.set(post.slug || post.link, stamp.getBoundingClientRect());
-        }
-
-        if (top < line - 4) return true;
-        if (top > line + 32) return false;
-        return previous[index] ?? false;
+      stampRefs.current.forEach((stamp, index) => {
+        if (!stamp) return;
+        const post = sortedPosts[index];
+        if (!post?.image) return;
+        originsRef.current.set(
+          post.slug || post.link,
+          stamp.getBoundingClientRect()
+        );
       });
-
-      if (
-        next.length !== previous.length ||
-        next.some((value, index) => value !== previous[index])
-      ) {
-        collectedRef.current = next;
-        setCollected(next);
-      }
     };
 
     const scheduleSelection = () => {
@@ -279,11 +264,30 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
     };
   }, [sortedPosts]);
 
+  const selectedPostIndex = selection.currentIndex;
+  const titleSeeds = useMemo(
+    () =>
+      sortedPosts.flatMap((post, postIndex) =>
+        post.image && isTitleStampActive(postIndex, selectedPostIndex)
+          ? [post.slug || post.link]
+          : []
+      ),
+    [selectedPostIndex, sortedPosts]
+  );
+  const { fading: titleFading, keys: titleKeys } = useFadingPresence(titleSeeds);
+  const handleOffset = useCallback((seed: string, offset: StampOffset) => {
+    setOffsets((current) => ({ ...current, [seed]: offset }));
+  }, []);
+  const handleAlbumPositions = useCallback((rects: Map<string, DOMRect>) => {
+    albumRectsRef.current = rects;
+  }, []);
+
   if (!sortedPosts.length) return null;
 
-  const selectedPostIndex = selection.currentIndex;
   const albumItems = sortedPosts.flatMap((post, postIndex) => {
-    if (!collected[postIndex] || !post.image) return [];
+    if (!isStampCollected(postIndex, selectedPostIndex) || !post.image) {
+      return [];
+    }
     const seed = post.slug || post.link;
     return [
       {
@@ -332,10 +336,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
         />
 
         <div className="relative" ref={writingBarRef}>
-          <div
-            className="flex items-baseline justify-between gap-4"
-            ref={collectLineRef}
-          >
+          <div className="flex items-baseline justify-between gap-4">
             <h2
               id="posts-heading"
               className="font-serif text-3xl tracking-[-0.035em] text-foreground"
@@ -354,7 +355,13 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
               {String(sortedPosts.length).padStart(2, "0")}
             </p>
           </div>
-          <StampAlbum items={albumItems} slots={albumSlots} />
+          <StampAlbum
+            items={albumItems}
+            offsets={offsets}
+            onOffset={handleOffset}
+            onPositions={handleAlbumPositions}
+            slots={albumSlots}
+          />
         </div>
       </PinnedShell>
 
@@ -396,6 +403,12 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
 
           const { post, postIndex } = entry;
           const isSelected = postIndex === selectedPostIndex;
+          const seed = post.slug || post.link;
+          const collected = isStampCollected(postIndex, selectedPostIndex);
+          const showTitleStamp =
+            Boolean(post.image) &&
+            titleKeys.includes(seed) &&
+            !collected;
           // 0 for the title currently in the slot, rising for each one passed.
           const titleDepth = Math.min(
             Math.max(selectedPostIndex - postIndex, 0),
@@ -430,8 +443,9 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                   offset={titleOffset}
                   releaseAfter={rowSpan || undefined}
                 >
+                <div className="flex items-center gap-3 pb-1.5 pt-4">
                 <div
-                  className="origin-left transition-[transform,opacity] duration-500 [transition-timing-function:var(--ease-spring)] motion-reduce:transition-none"
+                  className="min-w-0 flex-1 origin-left transition-[transform,opacity] duration-500 [transition-timing-function:var(--ease-spring)] motion-reduce:transition-none"
                   style={{
                     opacity: titleDepth > 0 ? 0 : 1,
                     transform:
@@ -448,7 +462,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                 >
                 <Link
                   aria-current={isSelected ? "true" : undefined}
-                  className={`flex min-h-11 min-w-0 items-center pb-1.5 pt-4 text-[1.05rem] leading-snug tracking-[-0.015em] transition-colors duration-150 motion-reduce:transition-none ${
+                  className={`flex min-h-11 min-w-0 items-center text-[1.05rem] leading-snug tracking-[-0.015em] transition-colors duration-150 motion-reduce:transition-none ${
                     isSelected
                       ? "font-bold text-foreground"
                       : "font-normal text-muted/65 hover:text-foreground"
@@ -476,6 +490,26 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                   </span>
                 </Link>
                 </div>
+                {showTitleStamp && post.image ? (
+                  <span
+                    ref={(node) => {
+                      stampRefs.current[postIndex] = node;
+                    }}
+                    className="relative shrink-0"
+                  >
+                    <TitleStamp
+                      external={!post.slug}
+                      fading={titleFading(seed)}
+                      href={getPostHref(post)}
+                      offset={offsets[seed] ?? { x: 0, y: 0 }}
+                      onOffset={(next) => handleOffset(seed, next)}
+                      origin={albumRectsRef.current.get(seed)}
+                      seed={seed}
+                      src={post.image}
+                    />
+                  </span>
+                ) : null}
+                </div>
                 </PinnedShell>
 
                 {post.description ? (
@@ -484,7 +518,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                   // a second one would announce the same destination twice.
                   <Link
                     aria-hidden="true"
-                    className={`mb-6 block max-w-prose text-[0.9rem] leading-relaxed transition-colors duration-150 motion-reduce:transition-none ${
+                    className={`mb-8 block max-w-prose text-[0.9rem] leading-relaxed transition-colors duration-150 motion-reduce:transition-none ${
                       isSelected ? "text-muted/75" : "text-muted/45"
                     }`}
                     href={getPostHref(post)}
@@ -496,25 +530,6 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                   </Link>
                 ) : null}
 
-                {post.image ? (
-                  <div
-                    ref={(node) => {
-                      stampRefs.current[postIndex] = node;
-                    }}
-                    className={`mb-8 overflow-visible py-3 ${
-                      collected[postIndex] ? "invisible pointer-events-none" : ""
-                    }`}
-                  >
-                    <PostStamp
-                      decorative
-                      external={!post.slug}
-                      href={getPostHref(post)}
-                      seed={post.slug || post.link}
-                      sizes={IMAGE_SIZES}
-                      src={post.image}
-                    />
-                  </div>
-                ) : null}
               </div>
             </li>
           );

--- a/app/_components/post-visualizer.tsx
+++ b/app/_components/post-visualizer.tsx
@@ -11,7 +11,7 @@ import {
   useState,
 } from "react";
 import type { SubstackPost } from "@/types/substack-post";
-import { layoutStampAlbum } from "@/lib/stamp-album";
+import { getAlbumPiece, layoutStampAlbum } from "@/lib/stamp-album";
 import {
   isStampCollected,
   isTitleStampActive,
@@ -410,6 +410,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
             !collected &&
             (isTitleStampActive(postIndex, selectedPostIndex) ||
               titleFading(seed));
+          const stampPiece = post.image ? getAlbumPiece(seed) : null;
           // 0 for the title currently in the slot, rising for each one passed.
           const titleDepth = Math.min(
             Math.max(selectedPostIndex - postIndex, 0),
@@ -444,7 +445,14 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                   offset={titleOffset}
                   releaseAfter={rowSpan || undefined}
                 >
-                <div className="flex items-center gap-3 pb-1.5 pt-4">
+                <div
+                  className="flex items-center gap-3 pb-1.5 pt-4"
+                  style={
+                    stampPiece
+                      ? { minHeight: stampPiece.height }
+                      : undefined
+                  }
+                >
                 <div
                   className="min-w-0 flex-1 origin-left transition-[transform,opacity] duration-500 [transition-timing-function:var(--ease-spring)] motion-reduce:transition-none"
                   style={{
@@ -491,23 +499,29 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                   </span>
                 </Link>
                 </div>
-                {showTitleStamp && post.image ? (
+                {stampPiece ? (
                   <span
                     ref={(node) => {
                       stampRefs.current[postIndex] = node;
                     }}
-                    className="relative block shrink-0"
+                    className="relative block shrink-0 self-center"
+                    style={{
+                      width: stampPiece.width,
+                      height: stampPiece.height,
+                    }}
                   >
-                    <TitleStamp
-                      external={!post.slug}
-                      fading={titleFading(seed)}
-                      href={getPostHref(post)}
-                      offset={offsets[seed] ?? { x: 0, y: 0 }}
-                      onOffset={(next) => handleOffset(seed, next)}
-                      origin={albumRectsRef.current.get(seed)}
-                      seed={seed}
-                      src={post.image}
-                    />
+                    {showTitleStamp ? (
+                      <TitleStamp
+                        external={!post.slug}
+                        fading={titleFading(seed)}
+                        href={getPostHref(post)}
+                        offset={offsets[seed] ?? { x: 0, y: 0 }}
+                        onOffset={(next) => handleOffset(seed, next)}
+                        origin={albumRectsRef.current.get(seed)}
+                        seed={seed}
+                        src={post.image}
+                      />
+                    ) : null}
                   </span>
                 ) : null}
                 </div>

--- a/app/_components/post-visualizer.tsx
+++ b/app/_components/post-visualizer.tsx
@@ -407,8 +407,9 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
           const collected = isStampCollected(postIndex, selectedPostIndex);
           const showTitleStamp =
             Boolean(post.image) &&
-            titleKeys.includes(seed) &&
-            !collected;
+            !collected &&
+            (isTitleStampActive(postIndex, selectedPostIndex) ||
+              titleFading(seed));
           // 0 for the title currently in the slot, rising for each one passed.
           const titleDepth = Math.min(
             Math.max(selectedPostIndex - postIndex, 0),
@@ -495,7 +496,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                     ref={(node) => {
                       stampRefs.current[postIndex] = node;
                     }}
-                    className="relative shrink-0"
+                    className="relative block shrink-0"
                   >
                     <TitleStamp
                       external={!post.slug}

--- a/app/_components/post-visualizer.tsx
+++ b/app/_components/post-visualizer.tsx
@@ -10,9 +10,11 @@ import {
   useState,
 } from "react";
 import type { SubstackPost } from "@/types/substack-post";
+import { layoutStampAlbum } from "@/lib/stamp-album";
 import HighlighterText from "./highlighter-text";
 import { PinnedShell } from "./pinned-shell";
 import { PostStamp } from "./post-stamp";
+import { StampAlbum } from "./stamp-album";
 
 interface PostsVisualizerProps {
   posts: SubstackPost[];
@@ -126,9 +128,17 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
   );
   const sectionRef = useRef<HTMLElement>(null);
   const postRefs = useRef<Array<HTMLLIElement | null>>([]);
+  const stampRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const collectLineRef = useRef<HTMLDivElement>(null);
+  const writingBarRef = useRef<HTMLDivElement>(null);
+  const collectedRef = useRef<boolean[]>([]);
+  const originsRef = useRef<Map<string, DOMRect>>(new Map());
   // Average row height, used to release each pinned title after about one row
   // so it hands the slot to the next one instead of staying put.
   const [rowSpan, setRowSpan] = useState(0);
+  const [collected, setCollected] = useState<boolean[]>([]);
+  const [titleOffset, setTitleOffset] = useState(TITLE_OFFSET);
+  const [trayWidth, setTrayWidth] = useState(0);
 
   const sortedPosts = useMemo(
     () =>
@@ -159,7 +169,30 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
 
   useEffect(() => {
     dispatchSelection({ type: "reset" });
+    collectedRef.current = [];
+    originsRef.current.clear();
+    setCollected([]);
   }, [posts]);
+
+  useEffect(() => {
+    const bar = writingBarRef.current;
+    if (!bar) return;
+
+    const measureBar = () => {
+      const bounds = bar.getBoundingClientRect();
+      setTrayWidth(Math.round(bounds.width));
+      setTitleOffset(Math.round(52 + bounds.height));
+    };
+
+    measureBar();
+    const observer = new ResizeObserver(measureBar);
+    observer.observe(bar);
+    window.addEventListener("resize", measureBar);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", measureBar);
+    };
+  }, [collected]);
 
   useEffect(() => {
     const measureRowSpan = () => {
@@ -199,6 +232,35 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
       });
 
       dispatchSelection({ type: "select", index: nearestIndex });
+
+      // A stamp collects the first time it meets the Writing bar. The list
+      // slot stays put — collapsing it would yank the next stamp up into the
+      // line and collect the whole deck in one frame.
+      const line =
+        collectLineRef.current?.getBoundingClientRect().bottom ?? TITLE_OFFSET;
+      const previous = collectedRef.current;
+      const next = sortedPosts.map((post, index) => {
+        if (!post.image) return false;
+        const stamp = stampRefs.current[index];
+        if (!stamp) return previous[index] ?? false;
+
+        const top = stamp.getBoundingClientRect().top;
+        if (!(previous[index] ?? false)) {
+          originsRef.current.set(post.slug || post.link, stamp.getBoundingClientRect());
+        }
+
+        if (top < line - 4) return true;
+        if (top > line + 32) return false;
+        return previous[index] ?? false;
+      });
+
+      if (
+        next.length !== previous.length ||
+        next.some((value, index) => value !== previous[index])
+      ) {
+        collectedRef.current = next;
+        setCollected(next);
+      }
     };
 
     const scheduleSelection = () => {
@@ -220,6 +282,22 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
   if (!sortedPosts.length) return null;
 
   const selectedPostIndex = selection.currentIndex;
+  const albumItems = sortedPosts.flatMap((post, postIndex) => {
+    if (!collected[postIndex] || !post.image) return [];
+    const seed = post.slug || post.link;
+    return [
+      {
+        href: getPostHref(post),
+        origin: originsRef.current.get(seed),
+        seed,
+        src: post.image,
+      },
+    ];
+  });
+  const albumSlots = layoutStampAlbum(
+    albumItems.map((item) => item.seed),
+    trayWidth
+  );
 
   const returnToWritingStart = (event: MouseEvent<HTMLButtonElement>) => {
     const shouldReduceMotion = window.matchMedia(
@@ -253,26 +331,31 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
           className="pointer-events-none absolute inset-x-0 top-full h-8 bg-linear-to-b from-background to-transparent backdrop-blur-md [mask-image:linear-gradient(to_bottom,black,transparent)]"
         />
 
-        <div className="relative flex items-baseline justify-between gap-4">
-          <h2
-            id="posts-heading"
-            className="font-serif text-3xl tracking-[-0.035em] text-foreground"
+        <div className="relative" ref={writingBarRef}>
+          <div
+            className="flex items-baseline justify-between gap-4"
+            ref={collectLineRef}
           >
-            <button
-              aria-label="Return to the beginning of Writing"
-              className="-mx-2 min-h-11 cursor-pointer px-2 text-left transition-transform duration-150 active:scale-[0.98] motion-reduce:transition-none"
-              onClick={returnToWritingStart}
-              type="button"
+            <h2
+              id="posts-heading"
+              className="font-serif text-3xl tracking-[-0.035em] text-foreground"
             >
-              Writing
-            </button>
-          </h2>
-          <p className="text-sm tabular-nums text-muted/70">
-            {String(selectedPostIndex + 1).padStart(2, "0")} /{" "}
-            {String(sortedPosts.length).padStart(2, "0")}
-          </p>
+              <button
+                aria-label="Return to the beginning of Writing"
+                className="-mx-2 min-h-11 cursor-pointer px-2 text-left transition-transform duration-150 active:scale-[0.98] motion-reduce:transition-none"
+                onClick={returnToWritingStart}
+                type="button"
+              >
+                Writing
+              </button>
+            </h2>
+            <p className="text-sm tabular-nums text-muted/70">
+              {String(selectedPostIndex + 1).padStart(2, "0")} /{" "}
+              {String(sortedPosts.length).padStart(2, "0")}
+            </p>
+          </div>
+          <StampAlbum items={albumItems} slots={albumSlots} />
         </div>
-
       </PinnedShell>
 
       <ol className="relative px-1 pb-24 before:absolute before:bottom-0 before:left-4 before:top-0 before:w-px before:bg-border before:content-[''] sm:px-3 sm:before:left-[1.625rem]">
@@ -344,7 +427,7 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                     on an inner node — PinnedShell owns transform on the shell. */}
                 <PinnedShell
                   className="relative z-30"
-                  offset={TITLE_OFFSET}
+                  offset={titleOffset}
                   releaseAfter={rowSpan || undefined}
                 >
                 <div
@@ -414,7 +497,14 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                 ) : null}
 
                 {post.image ? (
-                  <div className="mb-8 overflow-visible py-3">
+                  <div
+                    ref={(node) => {
+                      stampRefs.current[postIndex] = node;
+                    }}
+                    className={`mb-8 overflow-visible py-3 ${
+                      collected[postIndex] ? "invisible pointer-events-none" : ""
+                    }`}
+                  >
                     <PostStamp
                       decorative
                       external={!post.slug}

--- a/app/_components/post-visualizer.tsx
+++ b/app/_components/post-visualizer.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import {
   type MouseEvent,
@@ -13,6 +12,7 @@ import {
 import type { SubstackPost } from "@/types/substack-post";
 import HighlighterText from "./highlighter-text";
 import { PinnedShell } from "./pinned-shell";
+import { PostStamp } from "./post-stamp";
 
 interface PostsVisualizerProps {
   posts: SubstackPost[];
@@ -414,24 +414,16 @@ export default function PostsVisualizer({ posts }: PostsVisualizerProps) {
                 ) : null}
 
                 {post.image ? (
-                  <Link
-                    aria-hidden="true"
-                    className="mb-8 block overflow-hidden rounded-xl border border-border bg-surface shadow-lg"
-                    href={getPostHref(post)}
-                    rel={post.slug ? undefined : "noopener noreferrer"}
-                    tabIndex={-1}
-                    target={post.slug ? undefined : "_blank"}
-                  >
-                    <Image
-                      alt=""
-                      className="h-[clamp(9rem,34vw,13rem)] w-full object-cover"
-                      height={400}
+                  <div className="mb-8 overflow-visible py-3">
+                    <PostStamp
+                      decorative
+                      external={!post.slug}
+                      href={getPostHref(post)}
+                      seed={post.slug || post.link}
                       sizes={IMAGE_SIZES}
                       src={post.image}
-                      unoptimized
-                      width={700}
                     />
-                  </Link>
+                  </div>
                 ) : null}
               </div>
             </li>

--- a/app/_components/stamp-album.tsx
+++ b/app/_components/stamp-album.tsx
@@ -87,6 +87,7 @@ function FlyingStamp({
         left: slot.x,
         top: slot.y,
         width: slot.width,
+        aspectRatio: "3 / 2",
         transformOrigin: "top left",
         zIndex: slot.z,
       }}

--- a/app/_components/stamp-album.tsx
+++ b/app/_components/stamp-album.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useLayoutEffect, useRef } from "react";
+import { STAMP_ALBUM_HEIGHT, type AlbumSlot } from "@/lib/stamp-album";
+import { PostStamp } from "./post-stamp";
+
+export interface AlbumStampItem {
+  href: string;
+  origin?: DOMRect;
+  seed: string;
+  src: string;
+}
+
+interface StampAlbumProps {
+  items: AlbumStampItem[];
+  slots: AlbumSlot[];
+}
+
+interface FlyingStampProps {
+  item: AlbumStampItem;
+  slot: AlbumSlot;
+}
+
+function FlyingStamp({ item, slot }: FlyingStampProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const played = useRef(false);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element || played.current) return;
+    played.current = true;
+
+    if (
+      !item.origin ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return;
+    }
+
+    const dest = element.getBoundingClientRect();
+    const dx = item.origin.left - dest.left;
+    const dy = item.origin.top - dest.top;
+    const sx = dest.width ? item.origin.width / dest.width : 1;
+    const sy = dest.height ? item.origin.height / dest.height : 1;
+
+    if (Math.abs(dx) < 2 && Math.abs(dy) < 2 && Math.abs(sx - 1) < 0.05) {
+      return;
+    }
+
+    element.animate(
+      [
+        { transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})` },
+        { transform: "translate(0, 0) scale(1)" },
+      ],
+      {
+        duration: 560,
+        easing: "cubic-bezier(0.23, 1, 0.32, 1)",
+        fill: "both",
+      }
+    );
+  }, [item.origin]);
+
+  return (
+    <span
+      ref={ref}
+      className="absolute will-change-transform"
+      style={{
+        left: slot.x,
+        top: slot.y,
+        width: slot.width,
+        transformOrigin: "top left",
+        zIndex: slot.z,
+      }}
+    >
+      <span
+        className="block"
+        style={{ transform: `rotate(${slot.rotate}deg)` }}
+      >
+        <PostStamp
+          decorative
+          href={item.href}
+          seed={item.seed}
+          sizes="96px"
+          src={item.src}
+          variant="album"
+        />
+      </span>
+    </span>
+  );
+}
+
+export function StampAlbum({ items, slots }: StampAlbumProps) {
+  if (!items.length) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="relative mt-3"
+      style={{ height: STAMP_ALBUM_HEIGHT }}
+    >
+      {items.map((item, index) => {
+        const slot = slots[index];
+        if (!slot) return null;
+
+        return <FlyingStamp item={item} key={item.seed} slot={slot} />;
+      })}
+    </div>
+  );
+}

--- a/app/_components/stamp-album.tsx
+++ b/app/_components/stamp-album.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useMemo, useRef } from "react";
 import { STAMP_ALBUM_HEIGHT, type AlbumSlot } from "@/lib/stamp-album";
+import { albumMountSeeds } from "@/lib/stamp-visibility";
+import { PlayableStamp, type StampOffset } from "./playable-stamp";
 import { PostStamp } from "./post-stamp";
+import { useFadingPresence } from "./use-fading-presence";
 
 export interface AlbumStampItem {
   href: string;
@@ -13,15 +16,27 @@ export interface AlbumStampItem {
 
 interface StampAlbumProps {
   items: AlbumStampItem[];
+  offsets: Record<string, StampOffset>;
+  onOffset: (seed: string, offset: StampOffset) => void;
+  onPositions?: (rects: Map<string, DOMRect>) => void;
   slots: AlbumSlot[];
 }
 
 interface FlyingStampProps {
+  fading?: boolean;
   item: AlbumStampItem;
+  offset: StampOffset;
+  onOffset: (offset: StampOffset) => void;
   slot: AlbumSlot;
 }
 
-function FlyingStamp({ item, slot }: FlyingStampProps) {
+function FlyingStamp({
+  fading = false,
+  item,
+  offset,
+  onOffset,
+  slot,
+}: FlyingStampProps) {
   const ref = useRef<HTMLSpanElement>(null);
   const played = useRef(false);
 
@@ -31,6 +46,7 @@ function FlyingStamp({ item, slot }: FlyingStampProps) {
     played.current = true;
 
     if (
+      fading ||
       !item.origin ||
       window.matchMedia("(prefers-reduced-motion: reduce)").matches
     ) {
@@ -58,12 +74,15 @@ function FlyingStamp({ item, slot }: FlyingStampProps) {
         fill: "both",
       }
     );
-  }, [item.origin]);
+  }, [fading, item.origin]);
 
   return (
     <span
       ref={ref}
-      className="absolute will-change-transform"
+      className={`absolute will-change-transform ${
+        fading ? "stamp-fade-out" : ""
+      }`}
+      data-stamp-seed={item.seed}
       style={{
         left: slot.x,
         top: slot.y,
@@ -76,33 +95,84 @@ function FlyingStamp({ item, slot }: FlyingStampProps) {
         className="block"
         style={{ transform: `rotate(${slot.rotate}deg)` }}
       >
-        <PostStamp
-          decorative
-          href={item.href}
-          seed={item.seed}
-          sizes="96px"
-          src={item.src}
-          variant="album"
-        />
+        <PlayableStamp offset={offset} onOffset={onOffset}>
+          <PostStamp
+            decorative
+            href={item.href}
+            seed={item.seed}
+            sizes="96px"
+            src={item.src}
+            variant="album"
+          />
+        </PlayableStamp>
       </span>
     </span>
   );
 }
 
-export function StampAlbum({ items, slots }: StampAlbumProps) {
+export function StampAlbum({
+  items,
+  offsets,
+  onOffset,
+  onPositions,
+  slots,
+}: StampAlbumProps) {
+  const trayRef = useRef<HTMLDivElement>(null);
+  const seeds = items.map((item) => item.seed);
+  const mountedSeeds = useMemo(
+    () => albumMountSeeds(slots, seeds),
+    [slots, seeds]
+  );
+  const { fading, keys } = useFadingPresence(mountedSeeds);
+  const bySeed = useMemo(
+    () => new Map(items.map((item) => [item.seed, item])),
+    [items]
+  );
+  const slotBySeed = useMemo(() => {
+    const map = new Map<string, AlbumSlot>();
+    seeds.forEach((seed, index) => {
+      const slot = slots[index];
+      if (slot) map.set(seed, slot);
+    });
+    return map;
+  }, [seeds, slots]);
+
+  useLayoutEffect(() => {
+    const tray = trayRef.current;
+    if (!tray || !onPositions) return;
+
+    const rects = new Map<string, DOMRect>();
+    tray.querySelectorAll<HTMLElement>("[data-stamp-seed]").forEach((node) => {
+      const seed = node.dataset.stampSeed;
+      if (seed) rects.set(seed, node.getBoundingClientRect());
+    });
+    onPositions(rects);
+  }, [keys, onPositions, offsets]);
+
   if (!items.length) return null;
 
   return (
     <div
+      ref={trayRef}
       aria-hidden="true"
       className="relative mt-3"
       style={{ height: STAMP_ALBUM_HEIGHT }}
     >
-      {items.map((item, index) => {
-        const slot = slots[index];
-        if (!slot) return null;
+      {keys.map((seed) => {
+        const item = bySeed.get(seed);
+        const slot = slotBySeed.get(seed);
+        if (!item || !slot) return null;
 
-        return <FlyingStamp item={item} key={item.seed} slot={slot} />;
+        return (
+          <FlyingStamp
+            fading={fading(seed)}
+            item={item}
+            key={seed}
+            offset={offsets[seed] ?? { x: 0, y: 0 }}
+            onOffset={(next) => onOffset(seed, next)}
+            slot={slot}
+          />
+        );
       })}
     </div>
   );

--- a/app/_components/stamp-album.tsx
+++ b/app/_components/stamp-album.tsx
@@ -96,7 +96,15 @@ function FlyingStamp({
         className="block"
         style={{ transform: `rotate(${slot.rotate}deg)` }}
       >
-        <PlayableStamp offset={offset} onOffset={onOffset}>
+        <PlayableStamp
+          offset={offset}
+          onOffset={(next) =>
+            onOffset({
+              x: Math.max(-72, Math.min(72, next.x)),
+              y: Math.max(-40, Math.min(40, next.y)),
+            })
+          }
+        >
           <PostStamp
             decorative
             href={item.href}
@@ -149,8 +157,6 @@ export function StampAlbum({
     });
     onPositions(rects);
   }, [keys, onPositions, offsets]);
-
-  if (!items.length) return null;
 
   return (
     <div

--- a/app/_components/title-stamp.tsx
+++ b/app/_components/title-stamp.tsx
@@ -69,10 +69,8 @@ export function TitleStamp({
   return (
     <span
       ref={ref}
-      className={`relative block shrink-0 ${fading ? "stamp-fade-out" : "stamp-fade-in"}`}
+      className={`absolute inset-0 ${fading ? "stamp-fade-out" : "stamp-fade-in"}`}
       style={{
-        width: piece.width,
-        aspectRatio: "3 / 2",
         transformOrigin: "top left",
       }}
     >

--- a/app/_components/title-stamp.tsx
+++ b/app/_components/title-stamp.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useLayoutEffect, useRef } from "react";
+import { getAlbumPiece } from "@/lib/stamp-album";
+import { PlayableStamp, type StampOffset } from "./playable-stamp";
+import { PostStamp } from "./post-stamp";
+
+interface TitleStampProps {
+  fading?: boolean;
+  href: string;
+  offset: StampOffset;
+  onOffset: (offset: StampOffset) => void;
+  origin?: DOMRect;
+  seed: string;
+  src: string;
+  external?: boolean;
+}
+
+export function TitleStamp({
+  fading = false,
+  href,
+  offset,
+  onOffset,
+  origin,
+  seed,
+  src,
+  external = false,
+}: TitleStampProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const played = useRef(false);
+  const piece = getAlbumPiece(seed);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element || played.current) return;
+    played.current = true;
+
+    if (
+      !origin ||
+      fading ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return;
+    }
+
+    const dest = element.getBoundingClientRect();
+    const dx = origin.left - dest.left;
+    const dy = origin.top - dest.top;
+    const sx = dest.width ? origin.width / dest.width : 1;
+    const sy = dest.height ? origin.height / dest.height : 1;
+
+    if (Math.abs(dx) < 2 && Math.abs(dy) < 2 && Math.abs(sx - 1) < 0.05) {
+      return;
+    }
+
+    element.animate(
+      [
+        { transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})` },
+        { transform: "translate(0, 0) scale(1)" },
+      ],
+      {
+        duration: 560,
+        easing: "cubic-bezier(0.23, 1, 0.32, 1)",
+        fill: "both",
+      }
+    );
+  }, [fading, origin]);
+
+  return (
+    <span
+      ref={ref}
+      className={`relative shrink-0 ${fading ? "stamp-fade-out" : "stamp-fade-in"}`}
+      style={{ width: piece.width, transformOrigin: "top left" }}
+    >
+      <span
+        className="block"
+        style={{ transform: `rotate(${piece.rotate}deg)` }}
+      >
+        <PlayableStamp
+          allowVerticalScroll
+          offset={offset}
+          onOffset={(next) =>
+            onOffset({
+              x: Math.max(-56, Math.min(56, next.x)),
+              y: Math.max(-32, Math.min(32, next.y)),
+            })
+          }
+        >
+          <PostStamp
+            decorative
+            external={external}
+            href={href}
+            seed={seed}
+            sizes="96px"
+            src={src}
+            variant="album"
+          />
+        </PlayableStamp>
+      </span>
+    </span>
+  );
+}

--- a/app/_components/title-stamp.tsx
+++ b/app/_components/title-stamp.tsx
@@ -69,7 +69,7 @@ export function TitleStamp({
   return (
     <span
       ref={ref}
-      className={`relative shrink-0 ${fading ? "stamp-fade-out" : "stamp-fade-in"}`}
+      className={`relative block shrink-0 ${fading ? "stamp-fade-out" : "stamp-fade-in"}`}
       style={{
         width: piece.width,
         aspectRatio: "3 / 2",

--- a/app/_components/title-stamp.tsx
+++ b/app/_components/title-stamp.tsx
@@ -70,7 +70,11 @@ export function TitleStamp({
     <span
       ref={ref}
       className={`relative shrink-0 ${fading ? "stamp-fade-out" : "stamp-fade-in"}`}
-      style={{ width: piece.width, transformOrigin: "top left" }}
+      style={{
+        width: piece.width,
+        aspectRatio: "3 / 2",
+        transformOrigin: "top left",
+      }}
     >
       <span
         className="block"

--- a/app/_components/use-fading-presence.ts
+++ b/app/_components/use-fading-presence.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fadingPresence, STAMP_FADE_MS } from "@/lib/stamp-visibility";
+
+/**
+ * Keep keys for a short fade after they leave `active`, then drop them so
+ * the caller can unmount.
+ */
+export function useFadingPresence(active: string[], fadeMs = STAMP_FADE_MS) {
+  const [presence, setPresence] = useState<Map<string, number>>(
+    () => new Map(active.map((key) => [key, 0]))
+  );
+
+  useEffect(() => {
+    const now = Date.now();
+    let next = fadingPresence(presence, active, now, fadeMs);
+    const same =
+      next.size === presence.size &&
+      [...next].every(([key, until]) => presence.get(key) === until);
+
+    if (!same) setPresence(next);
+    else next = presence;
+
+    const remaining = [...next.values()].filter((until) => until > 0);
+    if (!remaining.length) return;
+
+    const timeout = window.setTimeout(
+      () => {
+        setPresence((current) => fadingPresence(current, active, Date.now(), fadeMs));
+      },
+      Math.max(16, Math.min(...remaining) - now)
+    );
+
+    return () => window.clearTimeout(timeout);
+    // presence is read at effect time; feeding it back would loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active.join("|"), fadeMs]);
+
+  return {
+    fading: (key: string) => (presence.get(key) ?? 0) > 0,
+    keys: [...presence.keys()],
+  };
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -55,6 +55,7 @@
    one uniform colour edge to edge and Safari can tint its chrome from it. */
 html {
   min-width: 360px;
+  overflow-x: clip;
   scrollbar-gutter: stable;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -55,7 +55,8 @@
    one uniform colour edge to edge and Safari can tint its chrome from it. */
 html {
   min-width: 360px;
-  overflow-x: clip;
+  overflow-x: hidden;
+  overflow-y: auto;
   scrollbar-gutter: stable;
 }
 
@@ -67,6 +68,7 @@ body {
   font-family: var(--font-family-sans);
   max-width: 36rem;
   margin: 0 auto;
+  overflow-x: hidden;
   /* The header is in normal flow (pinned by transform), so no extra top space
      is needed for it. env() on the bottom is a no-op without viewport-fit=cover
      but is kept so the padding stays correct if cover is ever re-enabled. */

--- a/app/globals.css
+++ b/app/globals.css
@@ -29,6 +29,9 @@
   --accent-light: #FDBA74;
   --wish: #2E6F8A;
   --border: #E6E2D8;
+  --stamp-paper: #f4efe4;
+  --stamp-ink: rgba(41, 37, 36, 0.14);
+  --stamp-shadow: rgba(41, 37, 36, 0.16);
 }
 
 /* Dark Mode via system preference */
@@ -42,6 +45,9 @@
     --accent-light: #FDBA74;
     --wish: #7EB6C9;
     --border: #33302B;
+    --stamp-paper: #2c281e;
+    --stamp-ink: rgba(228, 228, 228, 0.16);
+    --stamp-shadow: rgba(0, 0, 0, 0.46);
   }
 }
 
@@ -314,6 +320,54 @@ dialog::backdrop {
 
 .artwork-destack-reveal {
   animation-name: artworkDestackReveal;
+}
+
+/* Postage-stamp paper: a solid inner rectangle plus a hole grid. Added
+   together, the holes only survive on the margin — the artwork stays intact,
+   and drop-shadow on the wrapper follows the perforated silhouette. */
+.stamp-paper {
+  --stamp-pitch: 12px;
+  --stamp-hole: calc(var(--stamp-pitch) * 0.38);
+  background-color: var(--stamp-paper);
+  padding: calc(var(--stamp-pitch) * 0.72);
+  transform-origin: center;
+  -webkit-mask-image:
+    linear-gradient(#000 0 0),
+    radial-gradient(circle, #0000 var(--stamp-hole), #000 calc(var(--stamp-hole) + 0.7px));
+  -webkit-mask-size:
+    calc(100% - var(--stamp-pitch)) calc(100% - var(--stamp-pitch)),
+    var(--stamp-pitch) var(--stamp-pitch);
+  -webkit-mask-position:
+    center,
+    calc(var(--stamp-pitch) / -2) calc(var(--stamp-pitch) / -2);
+  -webkit-mask-repeat: no-repeat, repeat;
+  -webkit-mask-composite: source-over;
+  mask-image:
+    linear-gradient(#000 0 0),
+    radial-gradient(circle, #0000 var(--stamp-hole), #000 calc(var(--stamp-hole) + 0.7px));
+  mask-size:
+    calc(100% - var(--stamp-pitch)) calc(100% - var(--stamp-pitch)),
+    var(--stamp-pitch) var(--stamp-pitch);
+  mask-position:
+    center,
+    calc(var(--stamp-pitch) / -2) calc(var(--stamp-pitch) / -2);
+  mask-repeat: no-repeat, repeat;
+  mask-composite: add;
+}
+
+.stamp-window {
+  box-shadow: inset 0 0 0 1px var(--stamp-ink);
+}
+
+.stamp-shadow {
+  filter: drop-shadow(0.12rem 0.4rem 0.65rem var(--stamp-shadow));
+  transform-origin: center;
+  transition: transform 220ms var(--ease-spring);
+}
+
+a.stamp-shadow:hover,
+a.stamp-shadow:focus-visible {
+  transform: translateY(-3px);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -374,6 +374,39 @@ a.stamp-shadow:focus-visible {
   transform: translateY(-3px);
 }
 
+.stamp-play {
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+
+.stamp-play[data-allow-scroll="true"] {
+  touch-action: pan-y;
+}
+
+.stamp-play[data-dragging="true"] {
+  cursor: grabbing;
+}
+
+.stamp-fade-out {
+  opacity: 0;
+  transition: opacity 180ms ease;
+  pointer-events: none;
+}
+
+.stamp-fade-in {
+  animation: stampFadeIn 180ms ease;
+}
+
+@keyframes stampFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -406,7 +439,8 @@ a.stamp-shadow:focus-visible {
   .artwork-stack-in,
   .artwork-stack-under,
   .artwork-destack-out,
-  .artwork-destack-reveal {
+  .artwork-destack-reveal,
+  .stamp-fade-in {
     animation: none;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -355,6 +355,10 @@ dialog::backdrop {
   mask-composite: add;
 }
 
+.stamp-paper-album {
+  padding: calc(var(--stamp-pitch) * 0.62);
+}
+
 .stamp-window {
   box-shadow: inset 0 0 0 1px var(--stamp-ink);
 }

--- a/lib/seeded-random.ts
+++ b/lib/seeded-random.ts
@@ -1,0 +1,21 @@
+/**
+ * Hash a string into a small deterministic PRNG (mulberry32 over an FNV-1a seed).
+ * Handmade marks — highlighter strokes, stamp poses — come out of this so they
+ * look irregular but never change under the reader.
+ */
+export function createRandom(seed: string): () => number {
+  let hash = 2166136261;
+
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return () => {
+    hash = (hash + 0x6d2b79f5) | 0;
+    let value = hash;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/lib/stamp-album.test.ts
+++ b/lib/stamp-album.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getAlbumPiece,
+  layoutStampAlbum,
+  STAMP_ALBUM_HEIGHT,
+} from "./stamp-album";
+
+const SEEDS = [
+  "we-are-artists",
+  "pen-or-pencil",
+  "writing-software",
+  "wealth",
+  "caring",
+  "hands-on",
+  "focus-and-failures",
+  "the-fire-inside",
+];
+
+test("returns the same album piece for the same seed", () => {
+  assert.deepEqual(getAlbumPiece("we-are-artists"), getAlbumPiece("we-are-artists"));
+});
+
+test("lays out the same tray the same way", () => {
+  assert.deepEqual(
+    layoutStampAlbum(SEEDS, 420),
+    layoutStampAlbum(SEEDS, 420)
+  );
+});
+
+test("fills the top row before stacking, and leaves gaps", () => {
+  const slots = layoutStampAlbum(SEEDS, 420);
+  const row = slots.filter((slot) => !slot.stacked);
+  const stacked = slots.filter((slot) => slot.stacked);
+
+  assert.ok(row.length >= 3, "a 420px tray should hold several stamps");
+  assert.ok(stacked.length >= 1, "overflow should pile onto the row");
+  assert.equal(row.length + stacked.length, SEEDS.length);
+
+  for (let index = 1; index < row.length; index += 1) {
+    const previous = row[index - 1];
+    const current = row[index];
+    const gap = current.x - (previous.x + previous.width);
+    assert.ok(gap >= 8, `row stamps should keep a gap, got ${gap}`);
+    assert.ok(current.x + current.width <= 420);
+  }
+
+  assert.ok(stacked.every((slot) => slot.z > row[row.length - 1].z));
+});
+
+test("does not squeeze a stamp into a leftover sliver", () => {
+  const first = getAlbumPiece(SEEDS[0]);
+  const tight = first.width + 20;
+  const slots = layoutStampAlbum(SEEDS.slice(0, 2), tight);
+
+  assert.equal(slots[0].stacked, false);
+  assert.equal(slots[1].stacked, true);
+});
+
+test("keeps the album band tall enough for a loose pile", () => {
+  assert.ok(STAMP_ALBUM_HEIGHT >= 70);
+});

--- a/lib/stamp-album.ts
+++ b/lib/stamp-album.ts
@@ -1,0 +1,127 @@
+import { createRandom } from "./seeded-random";
+
+export interface AlbumPiece {
+  /** Leading gap before this stamp when it still fits on the row. */
+  gap: number;
+  height: number;
+  rotate: number;
+  seed: string;
+  stackNudgeX: number;
+  stackNudgeY: number;
+  width: number;
+}
+
+export interface AlbumSlot {
+  height: number;
+  rotate: number;
+  stacked: boolean;
+  width: number;
+  x: number;
+  y: number;
+  z: number;
+}
+
+const MIN_WIDTH = 58;
+const MAX_WIDTH = 84;
+const HEIGHT_RATIO = 2 / 3;
+const ROW_TOP = 10;
+const EDGE_PAD = 4;
+
+/**
+ * How a stamp wants to sit in the album — size, gap, and the nudge it uses
+ * once the row is full and it has to land on the pile.
+ */
+export function getAlbumPiece(seed: string): AlbumPiece {
+  const random = createRandom(`album:${seed}`);
+  const width = MIN_WIDTH + random() * (MAX_WIDTH - MIN_WIDTH);
+
+  return {
+    gap: 8 + random() * 28,
+    height: width * HEIGHT_RATIO,
+    rotate: (random() - 0.5) * 16,
+    seed,
+    stackNudgeX: (random() - 0.5) * 22,
+    stackNudgeY: (random() - 0.5) * 14,
+    width,
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Fill the top of the tray left to right, leaving the seeded gaps. When the
+ * next stamp no longer fits — gaps are not squeezed to make room — it stacks
+ * on a stamp already in the row.
+ */
+export function layoutStampAlbum(
+  seeds: string[],
+  trayWidth: number
+): AlbumSlot[] {
+  if (trayWidth <= 0 || !seeds.length) return [];
+
+  const pieces = seeds.map(getAlbumPiece);
+  const firstInset = createRandom(`album-inset:${seeds[0]}`)() * 14;
+  const slots: AlbumSlot[] = [];
+  const row: AlbumSlot[] = [];
+  let cursor = 0;
+  let z = 1;
+
+  for (const piece of pieces) {
+    const nextX = row.length === 0 ? firstInset : cursor + piece.gap;
+    const fits = nextX + piece.width <= trayWidth - EDGE_PAD;
+
+    if (fits) {
+      const slot: AlbumSlot = {
+        height: piece.height,
+        rotate: piece.rotate,
+        stacked: false,
+        width: piece.width,
+        x: nextX,
+        y: ROW_TOP,
+        z: z++,
+      };
+      slots.push(slot);
+      row.push(slot);
+      cursor = nextX + piece.width;
+      continue;
+    }
+
+    if (!row.length) {
+      const width = Math.min(piece.width, Math.max(24, trayWidth - EDGE_PAD * 2));
+      slots.push({
+        height: width * HEIGHT_RATIO,
+        rotate: piece.rotate,
+        stacked: false,
+        width,
+        x: EDGE_PAD,
+        y: ROW_TOP,
+        z: z++,
+      });
+      row.push(slots[slots.length - 1]);
+      cursor = EDGE_PAD + width;
+      continue;
+    }
+
+    const hostIndex = Math.floor(
+      createRandom(`album-host:${piece.seed}`)() * row.length
+    );
+    const host = row[hostIndex];
+    const maxX = Math.max(0, trayWidth - piece.width - EDGE_PAD);
+
+    slots.push({
+      height: piece.height,
+      rotate: piece.rotate,
+      stacked: true,
+      width: piece.width,
+      x: clamp(host.x + piece.stackNudgeX, 0, maxX),
+      y: ROW_TOP + piece.stackNudgeY,
+      z: z++,
+    });
+  }
+
+  return slots;
+}
+
+export const STAMP_ALBUM_HEIGHT = ROW_TOP + MAX_WIDTH * HEIGHT_RATIO + 12;

--- a/lib/stamp-pose.test.ts
+++ b/lib/stamp-pose.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getStampPose } from "./stamp-pose";
+
+test("returns the same pose for the same seed", () => {
+  assert.deepEqual(
+    getStampPose("we-are-artists"),
+    getStampPose("we-are-artists")
+  );
+});
+
+test("different posts land in different places", () => {
+  const first = getStampPose("we-are-artists");
+  const second = getStampPose("pen-or-pencil");
+
+  assert.notDeepEqual(first, second);
+});
+
+test("keeps collectible stamps inside a readable range", () => {
+  const pose = getStampPose("writing-software");
+
+  assert.ok(["start", "center", "end"].includes(pose.align));
+  assert.ok(pose.rotate >= -7 && pose.rotate <= 7);
+  assert.ok(pose.shiftX >= -9 && pose.shiftX <= 9);
+  assert.ok(pose.shiftY >= -5 && pose.shiftY <= 5);
+  assert.ok(pose.width >= 0.72 && pose.width <= 0.88);
+  assert.ok(pose.pitch >= 11 && pose.pitch <= 13.4);
+});
+
+test("feature stamps stay larger and tilt less", () => {
+  const pose = getStampPose("we-are-artists", "feature");
+
+  assert.ok(Math.abs(pose.rotate) <= 4);
+  assert.ok(pose.width >= 0.9 && pose.width <= 0.98);
+});

--- a/lib/stamp-pose.ts
+++ b/lib/stamp-pose.ts
@@ -1,0 +1,39 @@
+import { createRandom } from "./seeded-random";
+
+export type StampAlign = "start" | "center" | "end";
+
+export interface StampPose {
+  align: StampAlign;
+  /** Perforation pitch, in px — slightly different tooth spacing per stamp. */
+  pitch: number;
+  /** Rotation in degrees. */
+  rotate: number;
+  /** Horizontal nudge in px. */
+  shiftX: number;
+  /** Vertical nudge in px. */
+  shiftY: number;
+  /** Width as a fraction of the host (0–1). */
+  width: number;
+}
+
+/**
+ * A stable, slightly messy placement for one stamp. The same seed always
+ * returns the same pose, so a post does not wander between renders.
+ */
+export function getStampPose(
+  seed: string,
+  variant: "collectible" | "feature" = "collectible"
+): StampPose {
+  const random = createRandom(seed);
+  const alignRoll = random();
+  const collectible = variant === "collectible";
+
+  return {
+    align: alignRoll < 0.34 ? "start" : alignRoll < 0.67 ? "end" : "center",
+    pitch: 11 + random() * 2.4,
+    rotate: (random() - 0.5) * (collectible ? 14 : 8),
+    shiftX: (random() - 0.5) * (collectible ? 18 : 10),
+    shiftY: (random() - 0.5) * (collectible ? 10 : 6),
+    width: collectible ? 0.72 + random() * 0.16 : 0.9 + random() * 0.08,
+  };
+}

--- a/lib/stamp-visibility.test.ts
+++ b/lib/stamp-visibility.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ALBUM_PILE_VISIBLE,
+  albumMountSeeds,
+  fadingPresence,
+  isStampCollected,
+  isTitleStampActive,
+  STAMP_FADE_MS,
+  TITLE_STAMP_WINDOW,
+} from "./stamp-visibility";
+
+test("collects a stamp only after its post has been scrolled past", () => {
+  assert.equal(isStampCollected(0, 0), false);
+  assert.equal(isStampCollected(0, 1), true);
+  assert.equal(isStampCollected(3, 3), false);
+  assert.equal(isStampCollected(2, 3), true);
+});
+
+test("keeps title stamps for the current post and a short window ahead", () => {
+  assert.equal(isTitleStampActive(5, 5), true);
+  assert.equal(isTitleStampActive(5 + TITLE_STAMP_WINDOW, 5), true);
+  assert.equal(isTitleStampActive(5 + TITLE_STAMP_WINDOW + 1, 5), false);
+  assert.equal(isTitleStampActive(4, 5), false);
+});
+
+test("keeps the album row and only the top of the pile mounted", () => {
+  const slots = [
+    { stacked: false },
+    { stacked: false },
+    { stacked: false },
+    ...Array.from({ length: ALBUM_PILE_VISIBLE + 5 }, () => ({ stacked: true })),
+  ];
+  const seeds = slots.map((_, index) => `s${index}`);
+  const mounted = albumMountSeeds(slots, seeds);
+
+  assert.deepEqual(mounted.slice(0, 3), ["s0", "s1", "s2"]);
+  assert.equal(mounted.length, 3 + ALBUM_PILE_VISIBLE);
+  assert.ok(!mounted.includes("s3"));
+  assert.ok(mounted.includes(`s${slots.length - 1}`));
+});
+
+test("holds a departing key until the fade elapses, then drops it", () => {
+  const active = fadingPresence(new Map(), ["a", "b"], 1000, STAMP_FADE_MS);
+  assert.deepEqual([...active.keys()], ["a", "b"]);
+
+  const fading = fadingPresence(active, ["a"], 1000, STAMP_FADE_MS);
+  assert.equal(fading.get("b"), 1000 + STAMP_FADE_MS);
+
+  const gone = fadingPresence(fading, ["a"], 1000 + STAMP_FADE_MS, STAMP_FADE_MS);
+  assert.equal(gone.has("b"), false);
+  assert.equal(gone.get("a"), 0);
+});

--- a/lib/stamp-visibility.ts
+++ b/lib/stamp-visibility.ts
@@ -1,0 +1,81 @@
+import type { AlbumSlot } from "./stamp-album";
+
+/** Title stamps mounted around the current post — enough to scroll into. */
+export const TITLE_STAMP_WINDOW = 4;
+
+/**
+ * Buried album stamps under the pile. The row stays; only the top of the
+ * stack is worth keeping on screen.
+ */
+export const ALBUM_PILE_VISIBLE = 10;
+
+export const STAMP_FADE_MS = 180;
+
+/** A stamp sits beside its title until that post has been scrolled past. */
+export function isStampCollected(
+  postIndex: number,
+  selectedIndex: number
+): boolean {
+  return postIndex < selectedIndex;
+}
+
+/**
+ * Title-side stamps for the current post and a few still ahead. Past posts
+ * live in the album; far-ahead ones remount as we scroll down to them.
+ */
+export function isTitleStampActive(
+  postIndex: number,
+  selectedIndex: number
+): boolean {
+  return (
+    !isStampCollected(postIndex, selectedIndex) &&
+    postIndex <= selectedIndex + TITLE_STAMP_WINDOW
+  );
+}
+
+/**
+ * Seeds that should stay mounted in the album: every stamp still on the row,
+ * plus the most recent stamps in the pile.
+ */
+export function albumMountSeeds(
+  slots: Array<Pick<AlbumSlot, "stacked">>,
+  seeds: string[]
+): string[] {
+  const row: string[] = [];
+  const stacked: string[] = [];
+
+  slots.forEach((slot, index) => {
+    const seed = seeds[index];
+    if (!seed) return;
+    if (slot.stacked) stacked.push(seed);
+    else row.push(seed);
+  });
+
+  return [...row, ...stacked.slice(-ALBUM_PILE_VISIBLE)];
+}
+
+/**
+ * Keep departing keys for `fadeMs` so a fade-out can finish before unmount.
+ * `now` is injected so the fade window is testable.
+ */
+export function fadingPresence(
+  previous: Map<string, number>,
+  active: Iterable<string>,
+  now: number,
+  fadeMs: number
+): Map<string, number> {
+  const activeSet = new Set(active);
+  const next = new Map<string, number>();
+
+  for (const key of activeSet) {
+    next.set(key, 0);
+  }
+
+  for (const [key, until] of previous) {
+    if (activeSet.has(key)) continue;
+    const deadline = until === 0 ? now + fadeMs : until;
+    if (deadline > now) next.set(key, deadline);
+  }
+
+  return next;
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "start": "next start",
     "sync-substack": "tsx scripts/sync-substack-posts.ts",
-    "test": "tsx --test server/location-data.test.ts server/location.test.ts server/shape.test.ts server/spotify.test.ts lib/location-display.test.ts lib/run-areas.test.ts lib/shape-runs.test.ts lib/stamp-album.test.ts lib/stamp-pose.test.ts lib/world-map.test.ts app/api/location/update/route.test.ts"
+    "test": "tsx --test server/location-data.test.ts server/location.test.ts server/shape.test.ts server/spotify.test.ts lib/location-display.test.ts lib/run-areas.test.ts lib/shape-runs.test.ts lib/stamp-album.test.ts lib/stamp-pose.test.ts lib/stamp-visibility.test.ts lib/world-map.test.ts app/api/location/update/route.test.ts"
   },
   "dependencies": {
     "@next/mdx": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "start": "next start",
     "sync-substack": "tsx scripts/sync-substack-posts.ts",
-    "test": "tsx --test server/location-data.test.ts server/location.test.ts server/shape.test.ts server/spotify.test.ts lib/location-display.test.ts lib/run-areas.test.ts lib/shape-runs.test.ts lib/stamp-pose.test.ts lib/world-map.test.ts app/api/location/update/route.test.ts"
+    "test": "tsx --test server/location-data.test.ts server/location.test.ts server/shape.test.ts server/spotify.test.ts lib/location-display.test.ts lib/run-areas.test.ts lib/shape-runs.test.ts lib/stamp-album.test.ts lib/stamp-pose.test.ts lib/world-map.test.ts app/api/location/update/route.test.ts"
   },
   "dependencies": {
     "@next/mdx": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "start": "next start",
     "sync-substack": "tsx scripts/sync-substack-posts.ts",
-    "test": "tsx --test server/location-data.test.ts server/location.test.ts server/shape.test.ts server/spotify.test.ts lib/location-display.test.ts lib/run-areas.test.ts lib/shape-runs.test.ts lib/world-map.test.ts app/api/location/update/route.test.ts"
+    "test": "tsx --test server/location-data.test.ts server/location.test.ts server/shape.test.ts server/spotify.test.ts lib/location-display.test.ts lib/run-areas.test.ts lib/shape-runs.test.ts lib/stamp-pose.test.ts lib/world-map.test.ts app/api/location/update/route.test.ts"
   },
   "dependencies": {
     "@next/mdx": "^16.0.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stamps fit these drawings better than frames. A frame adds museum chrome around a painting; a stamp treats the same picture as something collected, which matches a writing index and the rest of the handmade page.

Each stamp now lives next to its post title. Scrolling past a post flies the stamp into the leftover space under Writing, leaving the seeded gaps. Gaps are not squeezed to fit one more — when the row is full, new stamps pile on. Scrolling back snaps the stamp home beside its title.

You can drag stamps on touch and mouse. A tap still opens the post; a drag does not. On title stamps, a mostly-vertical gesture is left to the page so scrolling is not stolen.

Performance: the scroll listener was already cheap (one rAF). The cost was dozens of masked images. Title stamps now mount only for the current post and a short window ahead. The album keeps the row plus the top of the pile; buried stamps fade out and unmount, then remount if you scroll back to them.

In-article images use the same paper and perforations, just larger and with less tilt.

## Walkthrough

![Writing list in light mode, stamp beside the title](https://cursor.com/artifacts/c/art-06e0ff42-e540-4627-945c-27674de2422c)
![Writing list in dark mode, stamp beside the title](https://cursor.com/artifacts/c/art-d7bb07af-f68c-47f8-9a2a-9a28bba29ec7)
![Stamps collected under Writing in light mode](https://cursor.com/artifacts/c/art-2bdb6f0b-a2d2-4895-bc6f-f51ed30f58b4)
![Stamps collected under Writing in dark mode](https://cursor.com/artifacts/c/art-830cd692-569b-47c8-acbf-cd7fc08e63e5)
![In-article stamp on a post, light mode](https://cursor.com/artifacts/c/art-1c00d8bc-5897-4c34-8a53-a54c8399d962)
![In-article stamp on a post, dark mode](https://cursor.com/artifacts/c/art-56a75810-6637-4fcb-a251-6f0be71129f8)

## Testing

- `npm test` (includes stamp pose, album packing, and visibility/cull tests)
- Visual check of the Writing list (at rest and collected) and a post page in light and dark

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00183-6dc8-73c1-8267-aa431ba4bfb0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00183-6dc8-73c1-8267-aa431ba4bfb0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

