### PR TITLE
Patch existing Vercel env ids instead of creating duplicates

### DIFF
--- a/server/vercel-env.test.ts
+++ b/server/vercel-env.test.ts
@@ -8,6 +8,71 @@ import {
   vercelTeamId,
 } from "./vercel-env";
 
+const PROJECT_ID = DEFAULT_VERCEL_PROJECT_ID;
+const TEAM_ID = DEFAULT_VERCEL_TEAM_ID;
+
+type FetchCall = { url: string; method: string; body: unknown };
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+function envListUrl(url: string): boolean {
+  return /\/v9\/projects\/[^/]+\/env(?:\?|$)/.test(url);
+}
+
+function envItemUrl(url: string, envId?: string): boolean {
+  if (envId) {
+    return url.includes(`/v9/projects/${PROJECT_ID}/env/${envId}`);
+  }
+  return /\/v9\/projects\/[^/]+\/env\/[^/?]+/.test(url);
+}
+
+function createEnvUrl(url: string): boolean {
+  return url.includes(`/v10/projects/${PROJECT_ID}/env`);
+}
+
+function projectUrl(url: string): boolean {
+  return (
+    url.includes(`/v9/projects/${PROJECT_ID}`) &&
+    !url.includes("/env")
+  );
+}
+
+async function withMockedFetch(
+  handler: (call: FetchCall) => Response,
+  run: (calls: FetchCall[]) => Promise<void>
+): Promise<void> {
+  const calls: FetchCall[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    const body = init?.body ? JSON.parse(String(init.body)) : null;
+    const call = { url, method, body };
+    calls.push(call);
+    return handler(call);
+  };
+  try {
+    await run(calls);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+function redeployHandlers(call: FetchCall): Response | null {
+  if (call.method === "GET" && projectUrl(call.url)) {
+    return jsonResponse({
+      name: "personal-website",
+      targets: { production: { id: "dpl_current" } },
+    });
+  }
+  if (call.method === "POST" && call.url.includes("/v13/deployments")) {
+    return jsonResponse({ id: "dpl_new" });
+  }
+  return null;
+}
+
 test("uses Vercel project and team env vars when present", () => {
   assert.equal(
     vercelProjectId({ VERCEL_PROJECT_ID: "prj_from_env" }),
@@ -22,60 +87,211 @@ test("falls back to the documented project and team IDs", () => {
   assert.equal(vercelTeamId({}), DEFAULT_VERCEL_TEAM_ID);
 });
 
-test("upserts env vars then redeploys the current production deployment", async () => {
-  const calls: Array<{ url: string; method: string; body: unknown }> = [];
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async (input, init) => {
-    const url = String(input);
-    const method = (init?.method ?? "GET").toUpperCase();
-    const body = init?.body ? JSON.parse(String(init.body)) : null;
-    calls.push({ url, method, body });
-
-    if (url.includes("/v10/projects/") && url.includes("/env")) {
-      return new Response(JSON.stringify({ created: [], failed: [] }), {
-        status: 201,
+test("creates missing env vars then redeploys the current production deployment", async () => {
+  await withMockedFetch(
+    (call) => {
+      if (call.method === "GET" && envListUrl(call.url)) {
+        return jsonResponse({ envs: [] });
+      }
+      if (call.method === "POST" && createEnvUrl(call.url)) {
+        return jsonResponse({ created: [], failed: [] }, 201);
+      }
+      const redeploy = redeployHandlers(call);
+      if (redeploy) return redeploy;
+      throw new Error(`Unexpected fetch ${call.method} ${call.url}`);
+    },
+    async (calls) => {
+      const ok = await persistVercelEnvAndRedeploy(
+        {
+          SPOTIFY_REFRESH_TOKEN: "new-token",
+          SPOTIFY_AUTHORIZED_AT: "2026-08-14T17:43:00.000Z",
+        },
+        { VERCEL_TOKEN: "vercel-token" }
+      );
+      assert.equal(ok, true);
+      assert.equal(calls.length, 4);
+      assert.equal(calls[0].method, "GET");
+      assert.match(calls[0].url, /\/v9\/projects\/prj_lskQL35c9gImwWjO4ZASmeK5yIUN\/env/);
+      assert.match(calls[0].url, new RegExp(`teamId=${TEAM_ID}`));
+      assert.equal(calls[1].method, "POST");
+      assert.match(calls[1].url, /\/v10\/projects\/prj_lskQL35c9gImwWjO4ZASmeK5yIUN\/env/);
+      assert.doesNotMatch(calls[1].url, /upsert=/);
+      assert.match(calls[1].url, new RegExp(`teamId=${TEAM_ID}`));
+      assert.deepEqual(calls[1].body, [
+        {
+          key: "SPOTIFY_REFRESH_TOKEN",
+          value: "new-token",
+          type: "encrypted",
+          target: ["production", "preview"],
+        },
+        {
+          key: "SPOTIFY_AUTHORIZED_AT",
+          value: "2026-08-14T17:43:00.000Z",
+          type: "encrypted",
+          target: ["production", "preview"],
+        },
+      ]);
+      assert.equal(calls[3].method, "POST");
+      assert.deepEqual(calls[3].body, {
+        name: "personal-website",
+        deploymentId: "dpl_current",
+        target: "production",
       });
     }
-    if (url.includes("/v9/projects/")) {
-      return new Response(
-        JSON.stringify({
-          name: "personal-website",
-          targets: { production: { id: "dpl_current" } },
-        }),
-        { status: 200 }
+  );
+});
+
+test("patches the existing production env id instead of posting a second row", async () => {
+  await withMockedFetch(
+    (call) => {
+      if (call.method === "GET" && envListUrl(call.url)) {
+        return jsonResponse({
+          envs: [
+            {
+              id: "env_authorized_prod",
+              key: "SPOTIFY_AUTHORIZED_AT",
+              type: "sensitive",
+              target: ["production"],
+            },
+            {
+              id: "env_refresh_all",
+              key: "SPOTIFY_REFRESH_TOKEN",
+              type: "encrypted",
+              target: ["production", "preview", "development"],
+            },
+          ],
+        });
+      }
+      if (call.method === "PATCH" && envItemUrl(call.url)) {
+        return jsonResponse({ id: "updated" });
+      }
+      const redeploy = redeployHandlers(call);
+      if (redeploy) return redeploy;
+      throw new Error(`Unexpected fetch ${call.method} ${call.url}`);
+    },
+    async (calls) => {
+      const ok = await persistVercelEnvAndRedeploy(
+        {
+          SPOTIFY_REFRESH_TOKEN: "new-token",
+          SPOTIFY_AUTHORIZED_AT: "2026-08-14T17:43:00.000Z",
+        },
+        { VERCEL_TOKEN: "vercel-token" }
+      );
+      assert.equal(ok, true);
+      const writes = calls.filter(
+        (call) => call.method === "POST" || call.method === "PATCH" || call.method === "DELETE"
+      );
+      const envWrites = writes.filter(
+        (call) => createEnvUrl(call.url) || envItemUrl(call.url)
+      );
+      assert.equal(envWrites.some((call) => call.method === "POST"), false);
+      assert.equal(envWrites.some((call) => createEnvUrl(call.url)), false);
+      assert.deepEqual(
+        envWrites.map((call) => ({ method: call.method, url: call.url, body: call.body })),
+        [
+          {
+            method: "PATCH",
+            url: `https://api.vercel.com/v9/projects/${PROJECT_ID}/env/env_refresh_all?teamId=${TEAM_ID}`,
+            body: {
+              value: "new-token",
+              type: "encrypted",
+              target: ["production", "preview", "development"],
+            },
+          },
+          {
+            method: "PATCH",
+            url: `https://api.vercel.com/v9/projects/${PROJECT_ID}/env/env_authorized_prod?teamId=${TEAM_ID}`,
+            body: {
+              value: "2026-08-14T17:43:00.000Z",
+              type: "sensitive",
+              target: ["production"],
+            },
+          },
+        ]
       );
     }
-    if (url.includes("/v13/deployments")) {
-      return new Response(JSON.stringify({ id: "dpl_new" }), { status: 200 });
-    }
-    throw new Error(`Unexpected fetch ${method} ${url}`);
-  };
+  );
+});
 
-  try {
-    const ok = await persistVercelEnvAndRedeploy(
-      {
-        SPOTIFY_REFRESH_TOKEN: "new-token",
-        SPOTIFY_AUTHORIZED_AT: "2026-08-14T17:43:00.000Z",
-      },
-      { VERCEL_TOKEN: "vercel-token" }
-    );
-    assert.equal(ok, true);
-    assert.equal(calls.length, 3);
-    assert.match(calls[0].url, /\/v10\/projects\/prj_lskQL35c9gImwWjO4ZASmeK5yIUN\/env/);
-    assert.match(calls[0].url, /upsert=true/);
-    assert.match(calls[0].url, /teamId=team_xmMLxDTGQiduMBDfRLlXFiMS/);
-    assert.equal(calls[0].method, "POST");
-    assert.deepEqual(
-      (calls[0].body as Array<{ key: string }>).map((item) => item.key),
-      ["SPOTIFY_REFRESH_TOKEN", "SPOTIFY_AUTHORIZED_AT"]
-    );
-    assert.equal(calls[2].method, "POST");
-    assert.deepEqual(calls[2].body, {
-      name: "personal-website",
-      deploymentId: "dpl_current",
-      target: "production",
-    });
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+test("deletes leftover ids for the same key after patching the production row", async () => {
+  await withMockedFetch(
+    (call) => {
+      if (call.method === "GET" && envListUrl(call.url)) {
+        return jsonResponse({
+          envs: [
+            {
+              id: "env_authorized_prod",
+              key: "SPOTIFY_AUTHORIZED_AT",
+              type: "sensitive",
+              target: ["production"],
+            },
+            {
+              id: "env_authorized_dup",
+              key: "SPOTIFY_AUTHORIZED_AT",
+              type: "encrypted",
+              target: ["production", "preview", "development"],
+            },
+            {
+              id: "env_refresh_all",
+              key: "SPOTIFY_REFRESH_TOKEN",
+              type: "encrypted",
+              target: ["production", "preview", "development"],
+            },
+            {
+              id: "env_refresh_dup",
+              key: "SPOTIFY_REFRESH_TOKEN",
+              type: "plain",
+              target: ["preview"],
+            },
+          ],
+        });
+      }
+      if (call.method === "PATCH" && envItemUrl(call.url)) {
+        return jsonResponse({ id: "updated" });
+      }
+      if (call.method === "DELETE" && envItemUrl(call.url)) {
+        return jsonResponse({ id: "deleted" });
+      }
+      const redeploy = redeployHandlers(call);
+      if (redeploy) return redeploy;
+      throw new Error(`Unexpected fetch ${call.method} ${call.url}`);
+    },
+    async (calls) => {
+      const ok = await persistVercelEnvAndRedeploy(
+        {
+          SPOTIFY_REFRESH_TOKEN: "new-token",
+          SPOTIFY_AUTHORIZED_AT: "2026-08-14T17:43:00.000Z",
+        },
+        { VERCEL_TOKEN: "vercel-token" }
+      );
+      assert.equal(ok, true);
+      const envWrites = calls.filter(
+        (call) => createEnvUrl(call.url) || envItemUrl(call.url)
+      );
+      assert.equal(
+        envWrites.some((call) => call.method === "POST" || createEnvUrl(call.url)),
+        false
+      );
+      assert.deepEqual(
+        envWrites.map((call) => `${call.method} ${call.url}`),
+        [
+          `PATCH https://api.vercel.com/v9/projects/${PROJECT_ID}/env/env_refresh_all?teamId=${TEAM_ID}`,
+          `DELETE https://api.vercel.com/v9/projects/${PROJECT_ID}/env/env_refresh_dup?teamId=${TEAM_ID}`,
+          `PATCH https://api.vercel.com/v9/projects/${PROJECT_ID}/env/env_authorized_prod?teamId=${TEAM_ID}`,
+          `DELETE https://api.vercel.com/v9/projects/${PROJECT_ID}/env/env_authorized_dup?teamId=${TEAM_ID}`,
+        ]
+      );
+      assert.deepEqual(envWrites[0].body, {
+        value: "new-token",
+        type: "encrypted",
+        target: ["production", "preview", "development"],
+      });
+      assert.equal(envWrites[1].body, null);
+      assert.deepEqual(envWrites[2].body, {
+        value: "2026-08-14T17:43:00.000Z",
+        type: "sensitive",
+        target: ["production"],
+      });
+    }
+  );
 });

--- a/server/vercel-env.ts
+++ b/server/vercel-env.ts
@@ -5,6 +5,15 @@ export const DEFAULT_VERCEL_TEAM_ID = "team_xmMLxDTGQiduMBDfRLlXFiMS";
 
 export type VercelEnvWrites = Record<string, string>;
 
+const NEW_ENV_TARGETS = ["production", "preview"] as const;
+
+type VercelEnvRow = {
+  id?: string;
+  key?: string;
+  type?: string;
+  target?: string[];
+};
+
 export function vercelProjectId(env: NodeJS.ProcessEnv = process.env): string {
   return env.VERCEL_PROJECT_ID || DEFAULT_VERCEL_PROJECT_ID;
 }
@@ -41,40 +50,185 @@ function requireVercelToken(env: NodeJS.ProcessEnv): string {
   return env.VERCEL_TOKEN;
 }
 
-export async function upsertVercelProjectEnv(
-  vars: VercelEnvWrites,
-  env: NodeJS.ProcessEnv = process.env
+function projectEnvCollectionPath(env: NodeJS.ProcessEnv): string {
+  return `/v9/projects/${encodeURIComponent(vercelProjectId(env))}/env`;
+}
+
+function projectEnvItemPath(env: NodeJS.ProcessEnv, envId: string): string {
+  return `${projectEnvCollectionPath(env)}/${encodeURIComponent(envId)}`;
+}
+
+function hasProductionTarget(row: VercelEnvRow): boolean {
+  return Array.isArray(row.target) && row.target.includes("production");
+}
+
+function isProductionOnly(row: VercelEnvRow): boolean {
+  return (
+    Array.isArray(row.target) &&
+    row.target.length === 1 &&
+    row.target[0] === "production"
+  );
+}
+
+/** Prefer the production-targeted row so runtime keeps the updated value. */
+function pickExistingVercelEnvRow(
+  rows: VercelEnvRow[]
+): VercelEnvRow | undefined {
+  const withId = rows.filter(
+    (row) => typeof row.id === "string" && row.id.length > 0
+  );
+  if (withId.length === 0) return undefined;
+  const production = withId.filter(hasProductionTarget);
+  const pool = production.length > 0 ? production : withId;
+  return pool.find(isProductionOnly) ?? pool[0];
+}
+
+function existingTargets(row: VercelEnvRow): string[] {
+  return Array.isArray(row.target) && row.target.length > 0
+    ? row.target
+    : [...NEW_ENV_TARGETS];
+}
+
+function existingType(row: VercelEnvRow): string {
+  return row.type && row.type.length > 0 ? row.type : "encrypted";
+}
+
+function parseEnvList(data: unknown): VercelEnvRow[] {
+  if (Array.isArray(data)) return data as VercelEnvRow[];
+  if (data && typeof data === "object" && "envs" in data) {
+    const envs = (data as { envs?: unknown }).envs;
+    if (Array.isArray(envs)) return envs as VercelEnvRow[];
+  }
+  return [];
+}
+
+async function listVercelProjectEnv(
+  token: string,
+  env: NodeJS.ProcessEnv
+): Promise<VercelEnvRow[]> {
+  const response = await fetch(vercelApiUrl(projectEnvCollectionPath(env), env), {
+    cache: "no-store",
+    headers: bearerHeaders(token),
+  });
+  if (!response.ok) {
+    console.error("Vercel env list failed", { status: response.status });
+    throw new Error(`Vercel env list failed (${response.status})`);
+  }
+  return parseEnvList(await response.json());
+}
+
+async function patchVercelProjectEnv(
+  token: string,
+  env: NodeJS.ProcessEnv,
+  row: VercelEnvRow,
+  value: string
 ): Promise<void> {
-  const token = requireVercelToken(env);
+  const envId = row.id;
+  if (!envId) {
+    throw new Error("Vercel env update failed");
+  }
+  const response = await fetch(
+    vercelApiUrl(projectEnvItemPath(env, envId), env),
+    {
+      method: "PATCH",
+      cache: "no-store",
+      headers: bearerHeaders(token, true),
+      body: JSON.stringify({
+        value,
+        type: existingType(row),
+        target: existingTargets(row),
+      }),
+    }
+  );
+  if (!response.ok) {
+    console.error("Vercel env update failed", { status: response.status });
+    throw new Error(`Vercel env update failed (${response.status})`);
+  }
+}
+
+async function deleteVercelProjectEnv(
+  token: string,
+  env: NodeJS.ProcessEnv,
+  envId: string
+): Promise<void> {
+  const response = await fetch(
+    vercelApiUrl(projectEnvItemPath(env, envId), env),
+    {
+      method: "DELETE",
+      cache: "no-store",
+      headers: bearerHeaders(token),
+    }
+  );
+  if (!response.ok) {
+    console.error("Vercel env delete failed", { status: response.status });
+    throw new Error(`Vercel env delete failed (${response.status})`);
+  }
+}
+
+async function createVercelProjectEnv(
+  token: string,
+  env: NodeJS.ProcessEnv,
+  created: Array<{ key: string; value: string }>
+): Promise<void> {
   const url = vercelApiUrl(
     `/v10/projects/${encodeURIComponent(vercelProjectId(env))}/env`,
-    env,
-    { upsert: "true" }
+    env
   );
-
   const response = await fetch(url, {
     method: "POST",
     cache: "no-store",
     headers: bearerHeaders(token, true),
     body: JSON.stringify(
-      Object.entries(vars).map(([key, value]) => ({
+      created.map(({ key, value }) => ({
         key,
         value,
         type: "encrypted",
-        target: ["production", "preview", "development"],
+        target: [...NEW_ENV_TARGETS],
       }))
     ),
   });
-
   if (!response.ok) {
     console.error("Vercel env update failed", { status: response.status });
     throw new Error(`Vercel env update failed (${response.status})`);
   }
-
   const data = (await response.json()) as { failed?: unknown[] };
   if (Array.isArray(data.failed) && data.failed.length > 0) {
     console.error("Vercel env update failed", { failed: data.failed.length });
     throw new Error("Vercel env update failed");
+  }
+}
+
+export async function upsertVercelProjectEnv(
+  vars: VercelEnvWrites,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<void> {
+  const token = requireVercelToken(env);
+  const existing = await listVercelProjectEnv(token, env);
+  const rowsByKey = new Map<string, VercelEnvRow[]>();
+  for (const row of existing) {
+    if (!row.key) continue;
+    const rows = rowsByKey.get(row.key) ?? [];
+    rows.push(row);
+    rowsByKey.set(row.key, rows);
+  }
+
+  const toCreate: Array<{ key: string; value: string }> = [];
+  for (const [key, value] of Object.entries(vars)) {
+    const rows = rowsByKey.get(key) ?? [];
+    const primary = pickExistingVercelEnvRow(rows);
+    if (!primary?.id) {
+      toCreate.push({ key, value });
+      continue;
+    }
+    await patchVercelProjectEnv(token, env, primary, value);
+    for (const leftover of rows) {
+      if (!leftover.id || leftover.id === primary.id) continue;
+      await deleteVercelProjectEnv(token, env, leftover.id);
+    }
+  }
+
+  if (toCreate.length > 0) {
+    await createVercelProjectEnv(token, env, toCreate);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`upsertVercelProjectEnv` POSTed to `/v10/projects/:id/env?upsert=true` with `target: ["production", "preview", "development"]` and `type: "encrypted"`.

That does not update a Production-only Sensitive row. Production already had a Production-only Sensitive `SPOTIFY_AUTHORIZED_AT` (and a separate older Non-sensitive `SPOTIFY_REFRESH_TOKEN` on all envs). The upsert created or updated a different row. `persist` returned success and Telegram fired, but the runtime kept the old Production-only value, so authorize still started OAuth after a successful reauth.

## Fix

Before writing, GET `/v9/projects/:projectId/env` (with `teamId`).

For each key:

- If a row exists, PATCH the existing production-targeted id (`/v9/projects/:projectId/env/:envId`) with the new value. Target and type stay as they already are. Do not POST a second row for the same key.
- If leftover rows exist for that key, delete those ids after the production row is updated.
- If no row exists, POST a new encrypted var targeted at `["production", "preview"]`.

`persistVercelEnvAndRedeploy` is unchanged in shape: write, then production redeploy. Errors still log status only — no token values, `VERCEL_TOKEN`, or env values.

## Tests

`server/vercel-env.test.ts` now covers:

- POST only when the key is missing
- PATCH the existing production id (no second POST)
- DELETE leftover ids for the same key

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b12428b9-9e54-49d1-a06f-046e85b38f80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b12428b9-9e54-49d1-a06f-046e85b38f80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

