### PR TITLE
Add a replay button for map and run drawings

### DIFF
--- a/app/_components/draw-replay.tsx
+++ b/app/_components/draw-replay.tsx
@@ -68,7 +68,7 @@ export function ReplayButton({ label }: { label: string }) {
   return (
     <button
       aria-label={label}
-      className="relative grid size-7 shrink-0 cursor-pointer place-items-center rounded-full text-muted/40 transition-[background-color,color,transform] duration-150 hover:bg-surface hover:text-foreground focus-visible:text-foreground active:scale-[0.94] motion-reduce:hidden after:absolute after:-inset-2 after:content-['']"
+      className="relative grid size-7 shrink-0 cursor-pointer place-items-center rounded-full text-muted/55 transition-[background-color,color,transform] duration-150 hover:bg-surface hover:text-foreground focus-visible:text-foreground active:scale-[0.94] motion-reduce:hidden after:absolute after:-inset-2 after:content-['']"
       onClick={replay}
       title={label}
       type="button"

--- a/app/_components/draw-replay.tsx
+++ b/app/_components/draw-replay.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface DrawReplayValue {
+  replay: () => void;
+  token: number;
+}
+
+const DrawReplayContext = createContext<DrawReplayValue | null>(null);
+
+export function DrawReplay({ children }: { children: ReactNode }) {
+  const [token, setToken] = useState(0);
+  const value = useMemo(
+    () => ({
+      replay: () => setToken((current) => current + 1),
+      token,
+    }),
+    [token]
+  );
+
+  return (
+    <DrawReplayContext.Provider value={value}>
+      {children}
+    </DrawReplayContext.Provider>
+  );
+}
+
+export function useDrawReplayToken(): number {
+  return useContext(DrawReplayContext)?.token ?? 0;
+}
+
+function ReplayIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-3.5"
+      fill="none"
+      viewBox="0 0 16 16"
+    >
+      <path
+        d="M3.2 8a4.8 4.8 0 1 0 1.35-3.32"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.25"
+      />
+      <path
+        d="M3.2 2.85v3.15h3.15"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.25"
+      />
+    </svg>
+  );
+}
+
+export function ReplayButton({ label }: { label: string }) {
+  const replay = useContext(DrawReplayContext)?.replay;
+  if (!replay) return null;
+
+  return (
+    <button
+      aria-label={label}
+      className="relative grid size-7 shrink-0 cursor-pointer place-items-center rounded-full text-muted/40 transition-[background-color,color,transform] duration-150 hover:bg-surface hover:text-foreground focus-visible:text-foreground active:scale-[0.94] motion-reduce:hidden after:absolute after:-inset-2 after:content-['']"
+      onClick={replay}
+      title={label}
+      type="button"
+    >
+      <ReplayIcon />
+    </button>
+  );
+}

--- a/app/_components/path-map.tsx
+++ b/app/_components/path-map.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useDrawReplayToken } from "./draw-replay";
 import type { PathSketch } from "@/lib/shape-runs";
 import { useEffect, useRef } from "react";
 
@@ -17,6 +18,8 @@ function drawDurations(count: number, budget: number): number[] {
 export function PathMap({ sketch }: { sketch: PathSketch }) {
   const svgRef = useRef<SVGSVGElement>(null);
   const frameRef = useRef(0);
+  const playRef = useRef<() => void>(() => {});
+  const replayToken = useDrawReplayToken();
 
   useEffect(() => {
     const node = svgRef.current;
@@ -39,6 +42,7 @@ export function PathMap({ sketch }: { sketch: PathSketch }) {
 
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
       reveal();
+      playRef.current = reveal;
       return;
     }
 
@@ -73,6 +77,8 @@ export function PathMap({ sketch }: { sketch: PathSketch }) {
       frameRef.current = requestAnimationFrame(tick);
     };
 
+    playRef.current = play;
+
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
@@ -92,6 +98,11 @@ export function PathMap({ sketch }: { sketch: PathSketch }) {
       cancelAnimationFrame(frameRef.current);
     };
   }, [sketch.path, sketch.traces]);
+
+  useEffect(() => {
+    if (replayToken === 0) return;
+    playRef.current();
+  }, [replayToken]);
 
   return (
     <svg

--- a/app/_components/places-map-frame.tsx
+++ b/app/_components/places-map-frame.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { DrawReplay, ReplayButton } from "./draw-replay";
 import PlaceCircles from "./places-map";
 import { getLocationPageData } from "@/server/location";
 import {
@@ -56,110 +57,115 @@ export function PlacesMap() {
   const continents = continentPaths();
 
   return (
-    <section
-      aria-labelledby="places-heading"
-      className="mt-10"
-      id="places-map"
-    >
-      <h2
-        id="places-heading"
-        className="font-serif text-3xl tracking-[-0.035em] text-foreground"
+    <DrawReplay>
+      <section
+        aria-labelledby="places-heading"
+        className="mt-10"
+        id="places-map"
       >
-        Places
-      </h2>
-      <p className="mt-2 text-sm leading-relaxed text-muted">
-        A rough map of recent regions, and a couple still ahead.
-      </p>
+        <div className="flex items-center gap-1.5">
+          <h2
+            id="places-heading"
+            className="font-serif text-3xl tracking-[-0.035em] text-foreground"
+          >
+            Places
+          </h2>
+          <ReplayButton label="Replay map drawing" />
+        </div>
+        <p className="mt-2 text-sm leading-relaxed text-muted">
+          A rough map of recent regions, and a couple still ahead.
+        </p>
 
-      <div
-        className="mt-5 w-full text-muted"
-        style={{ aspectRatio: `${VIEW_WIDTH} / ${VIEW_HEIGHT}` }}
-      >
-        <svg
-          aria-hidden="true"
-          className="block size-full overflow-visible"
-          viewBox={`${-MAP_PADDING} ${-MAP_PADDING} ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+        <div
+          className="mt-5 w-full text-muted"
+          style={{ aspectRatio: `${VIEW_WIDTH} / ${VIEW_HEIGHT}` }}
         >
-          <defs>
-            <filter
-              height="108%"
-              id="places-map-ink"
-              width="108%"
-              x="-4%"
-              y="-4%"
-            >
-              <feTurbulence
-                baseFrequency="0.012"
-                numOctaves="2"
-                result="noise"
-                seed="7"
-                type="fractalNoise"
-              />
-              <feDisplacementMap
-                in="SourceGraphic"
-                in2="noise"
-                scale="1.35"
-                xChannelSelector="R"
-                yChannelSelector="G"
-              />
-            </filter>
-            <filter
-              filterUnits="userSpaceOnUse"
-              height={MAP_HEIGHT + 48}
-              id="places-map-circles"
-              width={MAP_WIDTH + 48}
-              x={-24}
-              y={-24}
-            >
-              <feTurbulence
-                baseFrequency="0.04"
-                numOctaves={2}
-                result="grain"
-                seed={11}
-                type="fractalNoise"
-              />
-              <feDisplacementMap
-                in="SourceGraphic"
-                in2="grain"
-                scale={1.8}
-                xChannelSelector="R"
-                yChannelSelector="G"
-              />
-            </filter>
-          </defs>
+          <svg
+            aria-hidden="true"
+            className="block size-full overflow-visible"
+            viewBox={`${-MAP_PADDING} ${-MAP_PADDING} ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+          >
+            <defs>
+              <filter
+                height="108%"
+                id="places-map-ink"
+                width="108%"
+                x="-4%"
+                y="-4%"
+              >
+                <feTurbulence
+                  baseFrequency="0.012"
+                  numOctaves="2"
+                  result="noise"
+                  seed="7"
+                  type="fractalNoise"
+                />
+                <feDisplacementMap
+                  in="SourceGraphic"
+                  in2="noise"
+                  scale="1.35"
+                  xChannelSelector="R"
+                  yChannelSelector="G"
+                />
+              </filter>
+              <filter
+                filterUnits="userSpaceOnUse"
+                height={MAP_HEIGHT + 48}
+                id="places-map-circles"
+                width={MAP_WIDTH + 48}
+                x={-24}
+                y={-24}
+              >
+                <feTurbulence
+                  baseFrequency="0.04"
+                  numOctaves={2}
+                  result="grain"
+                  seed={11}
+                  type="fractalNoise"
+                />
+                <feDisplacementMap
+                  in="SourceGraphic"
+                  in2="grain"
+                  scale={1.8}
+                  xChannelSelector="R"
+                  yChannelSelector="G"
+                />
+              </filter>
+            </defs>
 
-          <g filter="url(#places-map-ink)">
-            {continents.map((continent) => (
-              <path
-                className="fill-surface stroke-current"
-                d={continent.d}
-                key={continent.name}
-                strokeLinejoin="round"
-                strokeWidth="1.35"
-              />
-            ))}
-          </g>
+            <g filter="url(#places-map-ink)">
+              {continents.map((continent) => (
+                <path
+                  className="fill-surface stroke-current"
+                  d={continent.d}
+                  key={continent.name}
+                  strokeLinejoin="round"
+                  strokeWidth="1.35"
+                />
+              ))}
+            </g>
 
-          <Suspense fallback={null}>
-            <CachedVisitedCircles />
-          </Suspense>
-        </svg>
-      </div>
+            <Suspense fallback={null}>
+              <CachedVisitedCircles />
+            </Suspense>
+          </svg>
+        </div>
 
-      <div className="mt-4 flex flex-wrap items-center gap-x-5 gap-y-1.5 text-xs text-muted">
-        <p className="inline-flex items-center gap-1.5">
-          <CircleSwatch kind="habitual" />
-          <span>Most of the time</span>
-        </p>
-        <p className="inline-flex items-center gap-1.5">
-          <CircleSwatch kind="casual" />
-          <span>Casual</span>
-        </p>
-        <p className="inline-flex items-center gap-1.5">
-          <CircleSwatch kind="wanted" />
-          <span>I&apos;d like to go</span>
-        </p>
-      </div>
-    </section>
+        <div className="mt-4 flex flex-wrap items-center gap-x-5 gap-y-1.5 text-xs text-muted">
+          <p className="inline-flex items-center gap-1.5">
+            <CircleSwatch kind="habitual" />
+            <span>Most of the time</span>
+          </p>
+          <p className="inline-flex items-center gap-1.5">
+            <CircleSwatch kind="casual" />
+            <span>Casual</span>
+          </p>
+          <p className="inline-flex items-center gap-1.5">
+            <CircleSwatch kind="wanted" />
+            <span>I&apos;d like to go</span>
+          </p>
+        </div>
+      </section>
+    </DrawReplay>
   );
 }

--- a/app/_components/places-map.tsx
+++ b/app/_components/places-map.tsx
@@ -97,15 +97,11 @@ export default function PlaceCircles({ places }: PlaceCirclesProps) {
     if (replayToken === 0) return;
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
 
+    // Hide first, then draw after a paint so the dashoffset transition can run
+    // from 1 rather than continuing from wherever the last stroke left off.
     setDrawn(false);
-    let second = 0;
-    const first = requestAnimationFrame(() => {
-      second = requestAnimationFrame(() => setDrawn(true));
-    });
-    return () => {
-      cancelAnimationFrame(first);
-      cancelAnimationFrame(second);
-    };
+    const id = window.setTimeout(() => setDrawn(true), 40);
+    return () => window.clearTimeout(id);
   }, [replayToken]);
 
   function activateClosest(event: PointerEvent<Element>, sticky: boolean) {

--- a/app/_components/places-map.tsx
+++ b/app/_components/places-map.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useDrawReplayToken } from "./draw-replay";
 import { useEffect, useMemo, useState, type PointerEvent } from "react";
 import type { VisitedPlace } from "@/server/location-data";
 import {
@@ -46,6 +47,7 @@ function markClass(circle: ZoneCircle): string {
 export default function PlaceCircles({ places }: PlaceCirclesProps) {
   const [activeLabel, setActiveLabel] = useState<string | null>(null);
   const [drawn, setDrawn] = useState(false);
+  const replayToken = useDrawReplayToken();
   const circles = useMemo(
     () => drawOrder([...wantedCircles(), ...zoneCircles(places)]),
     [places]
@@ -90,6 +92,21 @@ export default function PlaceCircles({ places }: PlaceCirclesProps) {
       armObserver.disconnect();
     };
   }, []);
+
+  useEffect(() => {
+    if (replayToken === 0) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    setDrawn(false);
+    let second = 0;
+    const first = requestAnimationFrame(() => {
+      second = requestAnimationFrame(() => setDrawn(true));
+    });
+    return () => {
+      cancelAnimationFrame(first);
+      cancelAnimationFrame(second);
+    };
+  }, [replayToken]);
 
   function activateClosest(event: PointerEvent<Element>, sticky: boolean) {
     const point = eventToSvgPoint(event);

--- a/app/_components/recent-runs.tsx
+++ b/app/_components/recent-runs.tsx
@@ -1,3 +1,4 @@
+import { DrawReplay, ReplayButton } from "./draw-replay";
 import { RunPaths } from "./run-paths";
 import { loadRunningSection } from "@/server/shape";
 import { cacheLife } from "next/cache";
@@ -14,19 +15,24 @@ async function CachedRunningPaths() {
 
 export default function RecentRuns() {
   return (
-    <section aria-labelledby="runs-heading" className="mt-10">
-      <h2
-        id="runs-heading"
-        className="font-serif text-3xl tracking-[-0.035em] text-foreground"
-      >
-        Running
-      </h2>
-      <p className="mt-4 leading-relaxed text-muted">
-        I started running as a trader, to empty my mind after intense sessions.
-        I kept the habit for stamina and endurance as I get older. I run early,
-        without music: birds, sunlight, and the occasional race for fun.
-      </p>
-      <CachedRunningPaths />
-    </section>
+    <DrawReplay>
+      <section aria-labelledby="runs-heading" className="mt-10">
+        <div className="flex items-center gap-1.5">
+          <h2
+            id="runs-heading"
+            className="font-serif text-3xl tracking-[-0.035em] text-foreground"
+          >
+            Running
+          </h2>
+          <ReplayButton label="Replay run drawings" />
+        </div>
+        <p className="mt-4 leading-relaxed text-muted">
+          I started running as a trader, to empty my mind after intense sessions.
+          I kept the habit for stamina and endurance as I get older. I run early,
+          without music: birds, sunlight, and the occasional race for fun.
+        </p>
+        <CachedRunningPaths />
+      </section>
+    </DrawReplay>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Places and Running now have a small replay control next to the heading. Clicking it restarts the stroke animations in place, instead of needing to scroll the section out of view and back.

The button is hidden when the user prefers reduced motion, matching the existing skip-draw behavior.

### Places
![Places replay button in light mode](https://cursor.com/artifacts/c/art-f53042e6-0032-491f-91ce-36c8022e1239)
![Places replay button in dark mode](https://cursor.com/artifacts/c/art-a80fa3e8-4feb-418e-af80-196dd2bf549c)

### Running
![Running replay button in light mode](https://cursor.com/artifacts/c/art-7fb8bec2-6e77-4cec-835f-fa3fb1b9bc90)
![Running replay button in dark mode](https://cursor.com/artifacts/c/art-29c88902-d71d-45c4-935d-a4702c068655)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd298190-02a9-44f9-aa79-52ffa03b6a92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd298190-02a9-44f9-aa79-52ffa03b6a92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

