### PR TITLE
Name Croix runs from a Lille stay beyond 8 km

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ in the same area. Each card is a smooth polyline of the latest loop
 with faint traces of the other runs there. The grid is captioned
 “Areas where I usually run.” Shape has no city field, so a card
 shows a place name only when the cluster sits near one of the few
-stays in `current_location`. Otherwise the name is omitted. Cards
+stays in `current_location` (within 15 km, wide enough for a Lille
+stay to cover runs in Croix). Route clustering itself stays at 8 km
+so distinct loops do not merge. Otherwise the name is omitted. Cards
 also show run count and day span. If the Shape key is missing, Shape
 is unreachable, or the live payload is empty, the page uses a
 checked-in snapshot of mapped runs (the same idea as the Lisbon home

--- a/lib/run-areas.test.ts
+++ b/lib/run-areas.test.ts
@@ -3,8 +3,10 @@ import test from "node:test";
 import {
   applyRunAreaNames,
   matchRunArea,
+  STAY_MATCH_RADIUS_KM,
   stayAreasFromPlaces,
 } from "./run-areas";
+import { CLUSTER_RADIUS_KM } from "./shape-runs";
 import type { DistinctPath } from "./shape-runs";
 
 function path(overrides: Partial<DistinctPath> = {}): DistinctPath {
@@ -36,12 +38,39 @@ function path(overrides: Partial<DistinctPath> = {}): DistinctPath {
 test("matches a cluster only when it sits on a known stay", () => {
   const areas = [
     { name: "Azeitão", center: [38.553, -9.018] as [number, number] },
-    { name: "Lille", center: [50.665, 3.166] as [number, number] },
+    { name: "Lille", center: [50.63, 3.06] as [number, number] },
   ];
 
   assert.equal(matchRunArea([38.553, -9.018], areas)?.name, "Azeitão");
-  assert.equal(matchRunArea([50.665, 3.166], areas)?.name, "Lille");
+  assert.equal(matchRunArea([50.63, 3.06], areas)?.name, "Lille");
   assert.equal(matchRunArea([48.8566, 2.3522], areas), null);
+});
+
+test("names Croix runs from a Lille stay just beyond the cluster radius", () => {
+  const croixCluster: [number, number] = [50.669, 3.173];
+  const lilleStay = { name: "Lille", center: [50.63, 3.06] as [number, number] };
+  const azeitaoStay = {
+    name: "Azeitão",
+    center: [38.52, -9.02] as [number, number],
+  };
+
+  assert.ok(STAY_MATCH_RADIUS_KM > CLUSTER_RADIUS_KM);
+  assert.equal(matchRunArea(croixCluster, [lilleStay], CLUSTER_RADIUS_KM), null);
+  assert.equal(matchRunArea(croixCluster, [lilleStay])?.name, "Lille");
+  assert.equal(matchRunArea(croixCluster, [azeitaoStay]), null);
+});
+
+test("prefers the nearer stay when Croix and Lille both match", () => {
+  assert.equal(
+    matchRunArea(
+      [50.669, 3.173],
+      [
+        { name: "Lille", center: [50.63, 3.06] },
+        { name: "Croix", center: [50.68, 3.15] },
+      ]
+    )?.name,
+    "Croix"
+  );
 });
 
 test("names cards from recent stays and leaves the rest blank", () => {
@@ -50,14 +79,22 @@ test("names cards from recent stays and leaves the rest blank", () => {
       path(),
       path({
         run: { ...path().run, id: "run-2" },
+        center: [50.669, 3.173],
+      }),
+      path({
+        run: { ...path().run, id: "run-3" },
         center: [48.8566, 2.3522],
       }),
     ],
-    [{ name: "Azeitão", center: [38.52, -9.02] }]
+    [
+      { name: "Azeitão", center: [38.52, -9.02] },
+      { name: "Lille", center: [50.63, 3.06] },
+    ]
   );
 
   assert.equal(named[0].placeName, "Azeitão");
-  assert.equal(named[1].placeName, null);
+  assert.equal(named[1].placeName, "Lille");
+  assert.equal(named[2].placeName, null);
 });
 
 test("reads stay cities as name sources", () => {

--- a/lib/run-areas.ts
+++ b/lib/run-areas.ts
@@ -1,18 +1,19 @@
-import {
-  CLUSTER_RADIUS_KM,
-  distanceKm,
-  type DistinctPath,
-} from "./shape-runs";
+import { distanceKm, type DistinctPath } from "./shape-runs";
 
 export interface RunArea {
   name: string;
   center: [number, number];
 }
 
+// Route clustering stays tight so two nearby loops become one card.
+// Naming is looser: a stay in Lille should still label runs in Croix
+// (~9 km), without reaching from Azeitão to Lisbon (~25 km).
+export const STAY_MATCH_RADIUS_KM = 15;
+
 export function matchRunArea(
   center: [number, number],
   areas: readonly RunArea[],
-  radiusKm = CLUSTER_RADIUS_KM
+  radiusKm = STAY_MATCH_RADIUS_KM
 ): RunArea | null {
   let nearest: RunArea | null = null;
   let nearestDistance = Infinity;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The homepage Running grid already had Lille/Croix in `current_location`, but the second card stayed unnamed.

**Cause:** Stay names reused the 8 km route-cluster radius. The usual loops sit in Croix (~50.67, 3.17). A Lille city-center stay (~50.63, 3.06) is about 9 km away, so the match failed. Azeitão still named correctly because those runs are ~3.5 km from that stay.

**Change:** Keep clustering at 8 km so distinct loops do not merge. Match stay names out to 15 km — enough for Lille ↔ Croix, not enough for Azeitão ↔ Lisbon (~25 km). If both Croix and Lille are stored, the nearer stay still wins.

After deploy, that card should read **Lille** (or **Croix** if that stay is closer). The running block is cached for hours, so the name may take a bit to show.

Light:

![Running cards named Azeitão and Lille in light mode](https://cursor.com/artifacts/c/art-64a0450e-f503-4c5b-8ab1-4ed3ddbd2ded)

Dark:

![Running cards named Azeitão and Lille in dark mode](https://cursor.com/artifacts/c/art-d806c139-010e-485e-8d4e-84199444d26a)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0051c-a418-7859-aea3-62bccf89cdab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0051c-a418-7859-aea3-62bccf89cdab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

