### PR TITLE
Fix link and spacing in “In a rush” post

### DIFF
--- a/content/substack/in-a-rush-a47.mdx
+++ b/content/substack/in-a-rush-a47.mdx
@@ -18,9 +18,9 @@ In a few months, Iâ€™ll be running 42 km (a marathon), but it feels like I canâ€
 
 I have priorities right now that make it so easy to say no to a run.
 
-I recently came across this guy,[Adrien Friggeri,](https://friggeri.net) who developed a web app that records all his runs for the last 10 years:
+I recently came across this guy, [Adrien Friggeri](https://friggeri.net), who developed a web app that records all his runs for the last 10 years:
 
-https://nodaysoff.run
+[https://nodaysoff.run](https://nodaysoff.run)
 
 ![](https://substackcdn.com/image/fetch/$s_!JEu7!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fcbb17e3a-e634-4f80-8b30-07d10e51975c_1355x885.png)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The [In a rush](https://www.hugodemenez.fr/posts/in-a-rush-a47) post had two content issues from the Substack import:

1. **Bare URL that was not a link** — `https://nodaysoff.run` rendered as plain text because the MDX compiler does not autolink URLs.
2. **Missing space after a comma** — `this guy,[Adrien Friggeri,]` had no space after the comma, and the trailing comma was inside the link text.

This updates the post to:

- `this guy, [Adrien Friggeri](https://friggeri.net),`
- `[https://nodaysoff.run](https://nodaysoff.run)`

## Preview

Light:

![In a rush post in light mode, with spaced comma and clickable nodaysoff.run link](https://cursor.com/artifacts/c/art-a56d48cb-bcf7-4f0f-ad27-cbb73151f4d1)

Dark:

![In a rush post in dark mode, with spaced comma and clickable nodaysoff.run link](https://cursor.com/artifacts/c/art-e1d4c17d-4a5b-4f35-9147-c2a48dc7ce65)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0053e-8e6b-7419-92c9-cb984d9f1a67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0053e-8e6b-7419-92c9-cb984d9f1a67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

