### PR TITLE
Delay run drawings until maps reach mid-screen

### DIFF
--- a/app/_components/path-map.tsx
+++ b/app/_components/path-map.tsx
@@ -79,22 +79,35 @@ export function PathMap({ sketch }: { sketch: PathSketch }) {
 
     playRef.current = play;
 
-    const observer = new IntersectionObserver(
+    // Two observers, far enough apart that a later pass can redraw without
+    // catching the paths erasing themselves on screen.
+    //
+    // Draw: wait until the map has reached the middle of the screen, so the
+    // stroke starts where the reader is looking rather than at the edge.
+    // The SVGs are short, so a threshold alone still fires at the bottom.
+    const drawObserver = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting) {
-          play();
-          return;
-        }
+        if (entry.isIntersecting) play();
+      },
+      { rootMargin: "0px 0px -45% 0px", threshold: 0.35 }
+    );
 
+    // Reset only once fully off screen. A small scroll back into the lower
+    // half should not hide paths that are still in view.
+    const resetObserver = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) return;
         cancelAnimationFrame(frameRef.current);
         hide();
       },
-      { threshold: 0.35 }
+      { threshold: 0 }
     );
 
-    observer.observe(node);
+    drawObserver.observe(node);
+    resetObserver.observe(node);
     return () => {
-      observer.disconnect();
+      drawObserver.disconnect();
+      resetObserver.disconnect();
       cancelAnimationFrame(frameRef.current);
     };
   }, [sketch.path, sketch.traces]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The run path animations were starting as soon as the small SVGs peeked into view. A 35% intersection threshold is not enough on a 64–80px-tall map — that is only a few pixels past the bottom edge.

This waits until each map has cleared the lower 45% of the viewport, so the stroke starts closer to the middle of the screen. A second observer still resets the drawing only after the map leaves the screen entirely, matching the highlighter and places-map pattern so a small scroll back does not erase paths that are still visible.

## Testing
- Scroll the homepage to the Running section and confirm drawings start later, nearer mid-viewport
- Scroll away and back to confirm they replay only after leaving the screen
- Replay button should still restart the drawings immediately

## Screenshots

Light:

![Running section in light mode, maps drawn mid-viewport](https://cursor.com/artifacts/c/art-786d2d4b-a377-42dc-8fdb-fb73e3f01acd)

Dark:

![Running section in dark mode, maps drawn mid-viewport](https://cursor.com/artifacts/c/art-9a6f1bc0-12fb-4aed-ad26-a0c85b0fc153)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00540-eee5-79cb-b5e9-4e2623c31843?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00540-eee5-79cb-b5e9-4e2623c31843&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

