### PR TITLE
Label the replay control and align it to the right

### DIFF
--- a/app/_components/draw-replay.tsx
+++ b/app/_components/draw-replay.tsx
@@ -68,12 +68,13 @@ export function ReplayButton({ label }: { label: string }) {
   return (
     <button
       aria-label={label}
-      className="relative grid size-7 shrink-0 cursor-pointer place-items-center rounded-full text-muted/55 transition-[background-color,color,transform] duration-150 hover:bg-surface hover:text-foreground focus-visible:text-foreground active:scale-[0.94] motion-reduce:hidden after:absolute after:-inset-2 after:content-['']"
+      className="relative inline-flex shrink-0 cursor-pointer items-center gap-1 rounded-full py-1 text-sm tracking-[-0.01em] text-muted/70 transition-[color,transform] duration-150 hover:text-foreground focus-visible:text-foreground active:scale-[0.98] motion-reduce:hidden after:absolute after:-inset-3 after:content-['']"
       onClick={replay}
       title={label}
       type="button"
     >
       <ReplayIcon />
+      <span>animation</span>
     </button>
   );
 }

--- a/app/_components/places-map-frame.tsx
+++ b/app/_components/places-map-frame.tsx
@@ -63,7 +63,7 @@ export function PlacesMap() {
         className="mt-10"
         id="places-map"
       >
-        <div className="flex items-center gap-1.5">
+        <div className="flex items-baseline justify-between gap-4">
           <h2
             id="places-heading"
             className="font-serif text-3xl tracking-[-0.035em] text-foreground"

--- a/app/_components/recent-runs.tsx
+++ b/app/_components/recent-runs.tsx
@@ -17,7 +17,7 @@ export default function RecentRuns() {
   return (
     <DrawReplay>
       <section aria-labelledby="runs-heading" className="mt-10">
-        <div className="flex items-center gap-1.5">
+        <div className="flex items-baseline justify-between gap-4">
           <h2
             id="runs-heading"
             className="font-serif text-3xl tracking-[-0.035em] text-foreground"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The replay control now sits on the right of the Places and Running headings, and the circular arrow is labeled **animation** so it’s obvious that it restarts the stroke drawings.

![Places heading with animation control, light](https://cursor.com/artifacts/c/art-ea53d251-a443-4afe-ae7e-7ebe0a28c3a0)
![Running heading with animation control, light](https://cursor.com/artifacts/c/art-b6362a3a-28a1-4fa6-9bd3-f32c5f6fe4e1)
![Places heading with animation control, dark](https://cursor.com/artifacts/c/art-ebade8e7-78e2-444b-a246-4a86d4fcfea5)
![Running heading with animation control, dark](https://cursor.com/artifacts/c/art-7fbf2838-0c36-4842-a7be-195664c85c57)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd298190-02a9-44f9-aa79-52ffa03b6a92?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd298190-02a9-44f9-aa79-52ffa03b6a92&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

