### PR TITLE
Fix blog lists rendering as oversized headings

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -8,7 +8,6 @@ import { cacheLife } from "next/cache";
 import { ImageGallery } from "./_components/image-gallery";
 import Link from "next/link";
 import { PinnedShell } from "@/app/_components/pinned-shell";
-import { repairDetachedMarkdownMarkers } from "@/lib/html-to-markdown";
 
 const CONTENT_DIR = path.join(process.cwd(), "content", "substack");
 
@@ -69,16 +68,14 @@ async function CachedBlogPost({ slug }: { slug: string }) {
     notFound();
   }
 
-  const source = repairDetachedMarkdownMarkers(
-    stripLeadingTitle(fs.readFileSync(filePath, "utf-8"))
-  );
+  const source = fs.readFileSync(filePath, "utf-8");
 
   try {
     const { content, frontmatter } = await compileMDX<{
       title?: string;
       date?: string;
     }>({
-      source,
+      source: stripLeadingTitle(source),
       options: { parseFrontmatter: true },
       components: mdxComponents,
     });

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { cacheLife } from "next/cache";
 import { ImageGallery } from "./_components/image-gallery";
 import Link from "next/link";
 import { PinnedShell } from "@/app/_components/pinned-shell";
+import { repairDetachedMarkdownMarkers } from "@/lib/html-to-markdown";
 
 const CONTENT_DIR = path.join(process.cwd(), "content", "substack");
 
@@ -68,14 +69,16 @@ async function CachedBlogPost({ slug }: { slug: string }) {
     notFound();
   }
 
-  const source = fs.readFileSync(filePath, "utf-8");
+  const source = repairDetachedMarkdownMarkers(
+    stripLeadingTitle(fs.readFileSync(filePath, "utf-8"))
+  );
 
   try {
     const { content, frontmatter } = await compileMDX<{
       title?: string;
       date?: string;
     }>({
-      source: stripLeadingTitle(source),
+      source,
       options: { parseFrontmatter: true },
       components: mdxComponents,
     });

--- a/content/substack/a-unique-coding-journey.mdx
+++ b/content/substack/a-unique-coding-journey.mdx
@@ -18,8 +18,6 @@ I started python programming in 2018 using a software called [Pyzo](https://pyzo
 
 That’s why I started switching to VSCode (In early 2018) even if my teacher wasn’t willing to make some effort to understand what were the advantages.
 
->
-
 > In fact, I was realizing that I’d work with VSCode for years to come, and that I had to take the risk to not get feedbacks from my teacher.
 
 I kept pushing with VSCode during my second engineering year. However, since I was working with other students (who were using Pyzo) on huge codebases, we only had one **GIANT** file of over **1500** lines of code. It was tough…
@@ -60,31 +58,17 @@ I was left with a 50 lines of code configuration.
 
 After 3-5 days, I realized I hadn’t code a single line of code regarding my personal projects. I decided to try using Vim to code python. I opened a script… and… said “no linting WTF? VSCode is much better… I go back to it (and maybe install Vim motion plugin).”
 
->
-
 > I was almost there… Ready to use Vim and enter the matrix. But due to my stupid kickstarter refactor, I was left with an unusable config of vim…
 
 I managed to get back into the creative process of programming… but it was on this not so personalized VSCode. I learned vim motions a bit (hjkl, diw, w, b, e keystroke used to navigate and delete words) thanks to the vim plugin.
 
 I wasn’t satisfied with my attempt. And then… after two weeks, I tried again.
-1.
-
-I installed the [NvChad](https://github.com/NvChad/NvChad) config.
-1.
-
-I opened Neovim.
-1.
-
-Got blasted with the look of it.
-1.
-
-Didn’t manage to use shortcuts.
-1.
-
-Read the documentation
-1.
-
-But finally started programming!!!
+1. I installed the [NvChad](https://github.com/NvChad/NvChad) config.
+1. I opened Neovim.
+1. Got blasted with the look of it.
+1. Didn’t manage to use shortcuts.
+1. Read the documentation
+1. But finally started programming!!!
 
 And then, after days managing to code using NeoVim, I can say that I fully got my PDE.
 
@@ -93,24 +77,12 @@ A PDE (Personalized Development Environment) is an IDE that is tailored to your 
 At first, it might look overwhelming, but you’ll see that it’s very minimal.
 
 I have :
-1.
-
-Treesitter (for code highlighting and parsing)
-1.
-
-LSP (Language Server Protocol) manager which handles linting in every languages I use.
-1.
-
-CMP and Copilot plugins (which handle completion)
-1.
-
-Git plugins to deal with git diff, git stages and commits
-1.
-
-Harpoon and Telescope (which handle the file navigation)
-1.
-
-Github theme and transparent background theme (to make my code looks good on my [Warp terminal](https://www.warp.dev/)
+1. Treesitter (for code highlighting and parsing)
+1. LSP (Language Server Protocol) manager which handles linting in every languages I use.
+1. CMP and Copilot plugins (which handle completion)
+1. Git plugins to deal with git diff, git stages and commits
+1. Harpoon and Telescope (which handle the file navigation)
+1. Github theme and transparent background theme (to make my code looks good on my [Warp terminal](https://www.warp.dev/)
 
 As I said, it might look overwhelming but it’s quite minimal and during the process of looking for the right plugins, I managed to understand how all of this works!
 

--- a/content/substack/a-unique-coding-journey.mdx
+++ b/content/substack/a-unique-coding-journey.mdx
@@ -18,6 +18,8 @@ I started python programming in 2018 using a software called [Pyzo](https://pyzo
 
 That’s why I started switching to VSCode (In early 2018) even if my teacher wasn’t willing to make some effort to understand what were the advantages.
 
+>
+
 > In fact, I was realizing that I’d work with VSCode for years to come, and that I had to take the risk to not get feedbacks from my teacher.
 
 I kept pushing with VSCode during my second engineering year. However, since I was working with other students (who were using Pyzo) on huge codebases, we only had one **GIANT** file of over **1500** lines of code. It was tough…
@@ -58,17 +60,31 @@ I was left with a 50 lines of code configuration.
 
 After 3-5 days, I realized I hadn’t code a single line of code regarding my personal projects. I decided to try using Vim to code python. I opened a script… and… said “no linting WTF? VSCode is much better… I go back to it (and maybe install Vim motion plugin).”
 
+>
+
 > I was almost there… Ready to use Vim and enter the matrix. But due to my stupid kickstarter refactor, I was left with an unusable config of vim…
 
 I managed to get back into the creative process of programming… but it was on this not so personalized VSCode. I learned vim motions a bit (hjkl, diw, w, b, e keystroke used to navigate and delete words) thanks to the vim plugin.
 
 I wasn’t satisfied with my attempt. And then… after two weeks, I tried again.
-1. I installed the [NvChad](https://github.com/NvChad/NvChad) config.
-1. I opened Neovim.
-1. Got blasted with the look of it.
-1. Didn’t manage to use shortcuts.
-1. Read the documentation
-1. But finally started programming!!!
+1.
+
+I installed the [NvChad](https://github.com/NvChad/NvChad) config.
+1.
+
+I opened Neovim.
+1.
+
+Got blasted with the look of it.
+1.
+
+Didn’t manage to use shortcuts.
+1.
+
+Read the documentation
+1.
+
+But finally started programming!!!
 
 And then, after days managing to code using NeoVim, I can say that I fully got my PDE.
 
@@ -77,12 +93,24 @@ A PDE (Personalized Development Environment) is an IDE that is tailored to your 
 At first, it might look overwhelming, but you’ll see that it’s very minimal.
 
 I have :
-1. Treesitter (for code highlighting and parsing)
-1. LSP (Language Server Protocol) manager which handles linting in every languages I use.
-1. CMP and Copilot plugins (which handle completion)
-1. Git plugins to deal with git diff, git stages and commits
-1. Harpoon and Telescope (which handle the file navigation)
-1. Github theme and transparent background theme (to make my code looks good on my [Warp terminal](https://www.warp.dev/)
+1.
+
+Treesitter (for code highlighting and parsing)
+1.
+
+LSP (Language Server Protocol) manager which handles linting in every languages I use.
+1.
+
+CMP and Copilot plugins (which handle completion)
+1.
+
+Git plugins to deal with git diff, git stages and commits
+1.
+
+Harpoon and Telescope (which handle the file navigation)
+1.
+
+Github theme and transparent background theme (to make my code looks good on my [Warp terminal](https://www.warp.dev/)
 
 As I said, it might look overwhelming but it’s quite minimal and during the process of looking for the right plugins, I managed to understand how all of this works!
 

--- a/content/substack/accept-you-target-and-focus-on-the.mdx
+++ b/content/substack/accept-you-target-and-focus-on-the.mdx
@@ -57,10 +57,18 @@ It’s like running. You set the mark, but you don’t obsess over it every seco
 ### **Actions: What Matters Every Day**
 
 Goals are nothing without action. Reflecting on my run and my business, I see it’s the daily steps that count. For my tool, that means a few clear moves:
-- Ensure customer satisfaction by replying to every request in 15 minutes.
-- Add features every two weeks, but only impactful ones at least two users ask for. No clutter.
-- Improve stability by keeping things simple, cutting bugs, and making it easy to maintain.
-- Make partnerships, at least one meaningful tie every two months.
+-
+
+Ensure customer satisfaction by replying to every request in 15 minutes.
+-
+
+Add features every two weeks, but only impactful ones at least two users ask for. No clutter.
+-
+
+Improve stability by keeping things simple, cutting bugs, and making it easy to maintain.
+-
+
+Make partnerships, at least one meaningful tie every two months.
 
 These aren’t fancy. They’re just what works. The list could grow, but I stick to what’s doable now.
 

--- a/content/substack/accept-you-target-and-focus-on-the.mdx
+++ b/content/substack/accept-you-target-and-focus-on-the.mdx
@@ -57,18 +57,10 @@ It’s like running. You set the mark, but you don’t obsess over it every seco
 ### **Actions: What Matters Every Day**
 
 Goals are nothing without action. Reflecting on my run and my business, I see it’s the daily steps that count. For my tool, that means a few clear moves:
--
-
-Ensure customer satisfaction by replying to every request in 15 minutes.
--
-
-Add features every two weeks, but only impactful ones at least two users ask for. No clutter.
--
-
-Improve stability by keeping things simple, cutting bugs, and making it easy to maintain.
--
-
-Make partnerships, at least one meaningful tie every two months.
+- Ensure customer satisfaction by replying to every request in 15 minutes.
+- Add features every two weeks, but only impactful ones at least two users ask for. No clutter.
+- Improve stability by keeping things simple, cutting bugs, and making it easy to maintain.
+- Make partnerships, at least one meaningful tie every two months.
 
 These aren’t fancy. They’re just what works. The list could grow, but I stick to what’s doable now.
 

--- a/content/substack/and-life-goes-by.mdx
+++ b/content/substack/and-life-goes-by.mdx
@@ -33,15 +33,9 @@ Now a weekend can feel over before it even starts.
 The brain plays tricks: when there are fewer new experiences, time seems to compress. When you try something new, the day fills with details, and time appears to stretch.
 
 So the easy idea is to keep things fresh.
--
-
-Try a different route home.
--
-
-Learn a small skill.
--
-
-Say yes to a random plan now and then.
+- Try a different route home.
+- Learn a small skill.
+- Say yes to a random plan now and then.
 
 You don’t need to reinvent your life; just add a few moments that your memory will store as interesting. Those moments slow the rush.
 
@@ -64,18 +58,10 @@ The contrast makes the moments you choose to be present actually feel present.
 ## Health: the simple engine behind presence
 
 There’s probably no magic trick to slowing time, but there is something close: basic health. (sleep, eat, drink well and practice sport reasonably well). When your body and brain work, you can make memories and stay in control.
-1.
-
-If you sleep well, your brain can access long-term memories and focus on what’s happening now. That makes being present easier.
-1.
-
-If you eat well, you feel energized and calm, not distracted by hunger or stomach aches.
-1.
-
-If you drink enough water, headaches stay away and your head feels clear. A small drink of alcohol now and then can be a social pleasure, but keeping it moderate helps your memory and sense of presence.
-1.
-
-If you move regularly, your energy and mood improve, and your body keeps up with the life you want to live.
+1. If you sleep well, your brain can access long-term memories and focus on what’s happening now. That makes being present easier.
+1. If you eat well, you feel energized and calm, not distracted by hunger or stomach aches.
+1. If you drink enough water, headaches stay away and your head feels clear. A small drink of alcohol now and then can be a social pleasure, but keeping it moderate helps your memory and sense of presence.
+1. If you move regularly, your energy and mood improve, and your body keeps up with the life you want to live.
 
 These aren’t rules to follow perfectly.
 

--- a/content/substack/and-life-goes-by.mdx
+++ b/content/substack/and-life-goes-by.mdx
@@ -33,9 +33,15 @@ Now a weekend can feel over before it even starts.
 The brain plays tricks: when there are fewer new experiences, time seems to compress. When you try something new, the day fills with details, and time appears to stretch.
 
 So the easy idea is to keep things fresh.
-- Try a different route home.
-- Learn a small skill.
-- Say yes to a random plan now and then.
+-
+
+Try a different route home.
+-
+
+Learn a small skill.
+-
+
+Say yes to a random plan now and then.
 
 You don’t need to reinvent your life; just add a few moments that your memory will store as interesting. Those moments slow the rush.
 
@@ -58,10 +64,18 @@ The contrast makes the moments you choose to be present actually feel present.
 ## Health: the simple engine behind presence
 
 There’s probably no magic trick to slowing time, but there is something close: basic health. (sleep, eat, drink well and practice sport reasonably well). When your body and brain work, you can make memories and stay in control.
-1. If you sleep well, your brain can access long-term memories and focus on what’s happening now. That makes being present easier.
-1. If you eat well, you feel energized and calm, not distracted by hunger or stomach aches.
-1. If you drink enough water, headaches stay away and your head feels clear. A small drink of alcohol now and then can be a social pleasure, but keeping it moderate helps your memory and sense of presence.
-1. If you move regularly, your energy and mood improve, and your body keeps up with the life you want to live.
+1.
+
+If you sleep well, your brain can access long-term memories and focus on what’s happening now. That makes being present easier.
+1.
+
+If you eat well, you feel energized and calm, not distracted by hunger or stomach aches.
+1.
+
+If you drink enough water, headaches stay away and your head feels clear. A small drink of alcohol now and then can be a social pleasure, but keeping it moderate helps your memory and sense of presence.
+1.
+
+If you move regularly, your energy and mood improve, and your body keeps up with the life you want to live.
 
 These aren’t rules to follow perfectly.
 

--- a/content/substack/beyond-the-classroom.mdx
+++ b/content/substack/beyond-the-classroom.mdx
@@ -74,8 +74,6 @@ I recommend looking at channels focusing on a particular topic for many years. A
 
 A friend of mine, recently suggested a great book to read :[“Too good they can’t ignore you”](https://www.goodreads.com/book/show/13525945-so-good-they-can-t-ignore-you). One of the takeaway is that you can become one of the best by being challenged by the best, guided by someone that achieved your goal.
 
->
-
 > The student surpasses the master
 
 You need dedication and motivation but that’s not the only thing needed in order to become great at something.

--- a/content/substack/beyond-the-classroom.mdx
+++ b/content/substack/beyond-the-classroom.mdx
@@ -74,6 +74,8 @@ I recommend looking at channels focusing on a particular topic for many years. A
 
 A friend of mine, recently suggested a great book to read :[“Too good they can’t ignore you”](https://www.goodreads.com/book/show/13525945-so-good-they-can-t-ignore-you). One of the takeaway is that you can become one of the best by being challenged by the best, guided by someone that achieved your goal.
 
+>
+
 > The student surpasses the master
 
 You need dedication and motivation but that’s not the only thing needed in order to become great at something.

--- a/content/substack/customer-pain.mdx
+++ b/content/substack/customer-pain.mdx
@@ -88,8 +88,6 @@ Gifts create a gentle bridge to honest feedback. They show customers you appreci
 
 In the end, trust comes from action and attention.
 
->
-
 > The more you relieve pain, the stronger your relationship becomes. And that is the best way to keep customers coming back.
 
 ![](https://substackcdn.com/image/fetch/$s_!_AQz!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F16fb742d-0e8e-4c65-9631-b99f3bdf63c9_1024x1024.png)

--- a/content/substack/customer-pain.mdx
+++ b/content/substack/customer-pain.mdx
@@ -88,6 +88,8 @@ Gifts create a gentle bridge to honest feedback. They show customers you appreci
 
 In the end, trust comes from action and attention.
 
+>
+
 > The more you relieve pain, the stronger your relationship becomes. And that is the best way to keep customers coming back.
 
 ![](https://substackcdn.com/image/fetch/$s_!_AQz!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F16fb742d-0e8e-4c65-9631-b99f3bdf63c9_1024x1024.png)

--- a/content/substack/customer-support-and-getting-traction.mdx
+++ b/content/substack/customer-support-and-getting-traction.mdx
@@ -36,6 +36,8 @@ Handling ten customers personally is doable. Fifty? That’s a different story. 
 
 Growth demands development. I see so many areas where improvements are essential:
 
+>
+
 > 1.**> Automated Roadmap:**> Customers deserve updates. A system where I can easily use markdown files to update the roadmap would help.
 
 > 2.**> Better Stripe Webhooks:**> My database doesn’t update if trial periods change in the Stripe dashboard. That’s a problem.

--- a/content/substack/customer-support-and-getting-traction.mdx
+++ b/content/substack/customer-support-and-getting-traction.mdx
@@ -36,8 +36,6 @@ Handling ten customers personally is doable. Fifty? That’s a different story. 
 
 Growth demands development. I see so many areas where improvements are essential:
 
->
-
 > 1.**> Automated Roadmap:**> Customers deserve updates. A system where I can easily use markdown files to update the roadmap would help.
 
 > 2.**> Better Stripe Webhooks:**> My database doesn’t update if trial periods change in the Stripe dashboard. That’s a problem.

--- a/content/substack/from-concept-to-kitchen.mdx
+++ b/content/substack/from-concept-to-kitchen.mdx
@@ -20,8 +20,6 @@ This article discusses my experiences in developing a product, emphasizing the c
 
 As I grew up,I began going to the grocery store on my own, transitioning from selecting food from the fridge to actively choosing ingredients for cooking.
 
->
-
 > In northern France, the norm is to have establishments known as hypermarkets, akin to Walmart. The concept originated in France with Carrefour and was subsequently adopted by Auchan. I am particularly familiar with Auchan, as it was founded by the Mulliez family in the 1960s, with deep roots in my local city of Roubaix-Croix.
 
 ![](https://substackcdn.com/image/fetch/$s_!Z67m!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F091e3a4a-6a42-4b24-9dac-502107e4e036.heic) [The first Auchan in Roubaix](http://projectivecities.aaschool.ac.uk/portfolio/the-critical-mass-of-french-mass-housing-and-mass-culture/07-first-auchan/) was officially inaugurated on March 27, 1961

--- a/content/substack/from-concept-to-kitchen.mdx
+++ b/content/substack/from-concept-to-kitchen.mdx
@@ -20,6 +20,8 @@ This article discusses my experiences in developing a product, emphasizing the c
 
 As I grew up,I began going to the grocery store on my own, transitioning from selecting food from the fridge to actively choosing ingredients for cooking.
 
+>
+
 > In northern France, the norm is to have establishments known as hypermarkets, akin to Walmart. The concept originated in France with Carrefour and was subsequently adopted by Auchan. I am particularly familiar with Auchan, as it was founded by the Mulliez family in the 1960s, with deep roots in my local city of Roubaix-Croix.
 
 ![](https://substackcdn.com/image/fetch/$s_!Z67m!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F091e3a4a-6a42-4b24-9dac-502107e4e036.heic) [The first Auchan in Roubaix](http://projectivecities.aaschool.ac.uk/portfolio/the-critical-mass-of-french-mass-housing-and-mass-culture/07-first-auchan/) was officially inaugurated on March 27, 1961

--- a/content/substack/harmful-plan-b.mdx
+++ b/content/substack/harmful-plan-b.mdx
@@ -74,8 +74,6 @@ At this stage in history, I think of him as a “normal” guy who managed to se
 
 Where he is not average, is when he truly dedicated to his vision. From there he applied the rule of sticking with plan A.
 
->
-
 > That’s where the definition of plan A is clear, plan A is the big project, a lifetime one. It is based on a vision of the future we have.
 
 His project / plan A, is to make the human species, multi-planetary. Under this main project, he realized that, FSD (full self driving) cars is important for the human species (reducing number of car accidents), allowing free speech (X/Twitter), using solar radiations to generate electricity (SolarCity now TeslaEnergy), restore nerves links from injured people, and allowing consciousness to control devices (Neuralink), preventing congestion in big cities by drilling tunnels (Boring Company).
@@ -97,7 +95,5 @@ Imagine thinking about something that could do harm and not having a second thou
 One thing we could do is to reduce our options to only have one plan to stick to.
 
 There are algorithms which works this way. The max algorithm for example (which finds the maximum of a list), it’ll store the first element, then compare it with the second and keep the highest one. You end up having only 2 thoughts simultaneously instead of X.
-
->
 
 > Indeed, you’d end up with 2 different thoughts at the same time (only during reflexion period that you have to keep short)

--- a/content/substack/harmful-plan-b.mdx
+++ b/content/substack/harmful-plan-b.mdx
@@ -74,6 +74,8 @@ At this stage in history, I think of him as a “normal” guy who managed to se
 
 Where he is not average, is when he truly dedicated to his vision. From there he applied the rule of sticking with plan A.
 
+>
+
 > That’s where the definition of plan A is clear, plan A is the big project, a lifetime one. It is based on a vision of the future we have.
 
 His project / plan A, is to make the human species, multi-planetary. Under this main project, he realized that, FSD (full self driving) cars is important for the human species (reducing number of car accidents), allowing free speech (X/Twitter), using solar radiations to generate electricity (SolarCity now TeslaEnergy), restore nerves links from injured people, and allowing consciousness to control devices (Neuralink), preventing congestion in big cities by drilling tunnels (Boring Company).
@@ -95,5 +97,7 @@ Imagine thinking about something that could do harm and not having a second thou
 One thing we could do is to reduce our options to only have one plan to stick to.
 
 There are algorithms which works this way. The max algorithm for example (which finds the maximum of a list), it’ll store the first element, then compare it with the second and keep the highest one. You end up having only 2 thoughts simultaneously instead of X.
+
+>
 
 > Indeed, you’d end up with 2 different thoughts at the same time (only during reflexion period that you have to keep short)

--- a/content/substack/how-reading-impacts-your-life.mdx
+++ b/content/substack/how-reading-impacts-your-life.mdx
@@ -48,8 +48,6 @@ It struck me recently that almost every person I truly admire is an avid reader 
 
 There is a connection there that I cannot ignore.
 
->
-
 > Words matter because thoughts are what make a person interesting in the first place.
 
 ![](https://substackcdn.com/image/fetch/$s_!t4a0!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc479e746-f6c8-46c4-9129-7dd3e8774a69_1536x1024.png)

--- a/content/substack/how-reading-impacts-your-life.mdx
+++ b/content/substack/how-reading-impacts-your-life.mdx
@@ -48,6 +48,8 @@ It struck me recently that almost every person I truly admire is an avid reader 
 
 There is a connection there that I cannot ignore.
 
+>
+
 > Words matter because thoughts are what make a person interesting in the first place.
 
 ![](https://substackcdn.com/image/fetch/$s_!t4a0!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc479e746-f6c8-46c4-9129-7dd3e8774a69_1536x1024.png)

--- a/content/substack/how-to-build-a-good-product.mdx
+++ b/content/substack/how-to-build-a-good-product.mdx
@@ -50,6 +50,8 @@ The greater the *perceived value*, the more likely they’ll make the switch.
 
 Switching to a new product isn’t just about desire—it’s also about the *friction*.
 
+>
+
 > • Is your product affordable enough?
 
 > • Does it solve problems without creating new ones?

--- a/content/substack/how-to-build-a-good-product.mdx
+++ b/content/substack/how-to-build-a-good-product.mdx
@@ -50,8 +50,6 @@ The greater the *perceived value*, the more likely they’ll make the switch.
 
 Switching to a new product isn’t just about desire—it’s also about the *friction*.
 
->
-
 > • Is your product affordable enough?
 
 > • Does it solve problems without creating new ones?

--- a/content/substack/i-am-empowered.mdx
+++ b/content/substack/i-am-empowered.mdx
@@ -26,6 +26,8 @@ I stumbled across a quote that hit me like a lightning bolt.
 
 It suggested that we shouldnt say I wrote this (would be a lie to ourselves) or AI wrote this (it didn’t by itself tho), but rather
 
+>
+
 > I wrote this using AI.
 
 It sounds simple, but it changed my entire world.

--- a/content/substack/i-am-empowered.mdx
+++ b/content/substack/i-am-empowered.mdx
@@ -26,8 +26,6 @@ I stumbled across a quote that hit me like a lightning bolt.
 
 It suggested that we shouldnt say I wrote this (would be a lie to ourselves) or AI wrote this (it didn’t by itself tho), but rather
 
->
-
 > I wrote this using AI.
 
 It sounds simple, but it changed my entire world.

--- a/content/substack/i-dont-believe-in-a-creator-i-believe.mdx
+++ b/content/substack/i-dont-believe-in-a-creator-i-believe.mdx
@@ -39,23 +39,17 @@ This trust, this working idea that our lives are more than random noise, is what
 Not as proof of a divine being, but as a practical label for destiny: the sense that what happens can matter, that purposes can grow, and that we can turn ourselves toward them.
 
 A few scientific ideas helped me shape this language in a way that felt real:
--
-
-First, there’s systems and emergence.
+- First, there’s systems and emergence.
 
 In physics and complexity science, simple rules on a tiny scale can create meaningful, ordered patterns on a bigger scale.
 
 Purpose doesn’t have to come from a designer; it can pop out naturally from how things interact.
--
-
-Then, there’s probability, limits, and cascade effects.
+- Then, there’s probability, limits, and cascade effects.
 
 Small nudges can lead to big changes when a system is sensitive to its starting point.
 
 This fits with a kind of “soft destiny”, trends and tendencies, not a rigid script.
--
-
-Finally, psychological meaning-making.
+- Finally, psychological meaning-making.
 
 Studies in psychology (and practices inspired by Viktor Frankl, who survived the Holocaust) show that people who find clear meaning in events tend to be more resilient and healthier emotionally.
 

--- a/content/substack/i-dont-believe-in-a-creator-i-believe.mdx
+++ b/content/substack/i-dont-believe-in-a-creator-i-believe.mdx
@@ -39,17 +39,23 @@ This trust, this working idea that our lives are more than random noise, is what
 Not as proof of a divine being, but as a practical label for destiny: the sense that what happens can matter, that purposes can grow, and that we can turn ourselves toward them.
 
 A few scientific ideas helped me shape this language in a way that felt real:
-- First, there’s systems and emergence.
+-
+
+First, there’s systems and emergence.
 
 In physics and complexity science, simple rules on a tiny scale can create meaningful, ordered patterns on a bigger scale.
 
 Purpose doesn’t have to come from a designer; it can pop out naturally from how things interact.
-- Then, there’s probability, limits, and cascade effects.
+-
+
+Then, there’s probability, limits, and cascade effects.
 
 Small nudges can lead to big changes when a system is sensitive to its starting point.
 
 This fits with a kind of “soft destiny”, trends and tendencies, not a rigid script.
-- Finally, psychological meaning-making.
+-
+
+Finally, psychological meaning-making.
 
 Studies in psychology (and practices inspired by Viktor Frankl, who survived the Holocaust) show that people who find clear meaning in events tend to be more resilient and healthier emotionally.
 

--- a/content/substack/just-showing-up-isnt-enough.mdx
+++ b/content/substack/just-showing-up-isnt-enough.mdx
@@ -48,4 +48,6 @@ You have control over your actions. If something doesn’t feel meaningful to yo
 
 ![](https://substackcdn.com/image/fetch/$s_!yP6x!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fa6dadc1f-4e01-48a6-9c79-d6f14fd0c6c6_1536x768.png)
 
+>
+
 > Life’s too short to waste time on things that don’t contribute to your growth or happiness. Don’t just go along for appearances or because “it looks good.” Put your effort into what moves you forward, what fulfills you. Showing up can be valuable, but only if it has purpose.

--- a/content/substack/just-showing-up-isnt-enough.mdx
+++ b/content/substack/just-showing-up-isnt-enough.mdx
@@ -48,6 +48,4 @@ You have control over your actions. If something doesn’t feel meaningful to yo
 
 ![](https://substackcdn.com/image/fetch/$s_!yP6x!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fa6dadc1f-4e01-48a6-9c79-d6f14fd0c6c6_1536x768.png)
 
->
-
 > Life’s too short to waste time on things that don’t contribute to your growth or happiness. Don’t just go along for appearances or because “it looks good.” Put your effort into what moves you forward, what fulfills you. Showing up can be valuable, but only if it has purpose.

--- a/content/substack/learning-is-fundamental.mdx
+++ b/content/substack/learning-is-fundamental.mdx
@@ -24,6 +24,8 @@ It could be a great goal, but is it worth pursuing?
 
 Here is what I might have learned this year:
 
+>
+
 > • I should not dive into too many different activities, or it could cost me, because quitting something is much harder than starting something.
 
 > • Reading things I love motivates me (biographies of entrepreneurs and inventors are what I love the most).

--- a/content/substack/learning-is-fundamental.mdx
+++ b/content/substack/learning-is-fundamental.mdx
@@ -24,8 +24,6 @@ It could be a great goal, but is it worth pursuing?
 
 Here is what I might have learned this year:
 
->
-
 > • I should not dive into too many different activities, or it could cost me, because quitting something is much harder than starting something.
 
 > • Reading things I love motivates me (biographies of entrepreneurs and inventors are what I love the most).

--- a/content/substack/life.mdx
+++ b/content/substack/life.mdx
@@ -61,15 +61,9 @@ I already have some potential clients lined up and others who might be intereste
 ## Looking forward
 
 In about a month, life will look very different:
--
-
-The work at home will be done.
--
-
-A baby girl will be part of the family.
--
-
-The business will have new directions to explore.
+- The work at home will be done.
+- A baby girl will be part of the family.
+- The business will have new directions to explore.
 
 It’s hard to fully imagine all these changes, but the excitement is undeniable.
 

--- a/content/substack/life.mdx
+++ b/content/substack/life.mdx
@@ -61,9 +61,15 @@ I already have some potential clients lined up and others who might be intereste
 ## Looking forward
 
 In about a month, life will look very different:
-- The work at home will be done.
-- A baby girl will be part of the family.
-- The business will have new directions to explore.
+-
+
+The work at home will be done.
+-
+
+A baby girl will be part of the family.
+-
+
+The business will have new directions to explore.
 
 It’s hard to fully imagine all these changes, but the excitement is undeniable.
 

--- a/content/substack/no-need-to-speak-just-do.mdx
+++ b/content/substack/no-need-to-speak-just-do.mdx
@@ -74,6 +74,8 @@ But as it grows, I am more and more eager to start this endeavor.
 
 ## Wisdom from a Renowned Entrepreneur
 
+>
+
 > No need to speak about what you’ll do. Just do it. Once you do, you are going to be copied (if you’re good enough).
 
 > Diffusion is much broader when a business is good. It’s much better for a business to work well because it is being copied rather than working because we spoke about it.

--- a/content/substack/no-need-to-speak-just-do.mdx
+++ b/content/substack/no-need-to-speak-just-do.mdx
@@ -74,8 +74,6 @@ But as it grows, I am more and more eager to start this endeavor.
 
 ## Wisdom from a Renowned Entrepreneur
 
->
-
 > No need to speak about what you’ll do. Just do it. Once you do, you are going to be copied (if you’re good enough).
 
 > Diffusion is much broader when a business is good. It’s much better for a business to work well because it is being copied rather than working because we spoke about it.

--- a/content/substack/open-sourcing.mdx
+++ b/content/substack/open-sourcing.mdx
@@ -25,17 +25,11 @@ The public repository hosts all the extensions available and built by the commun
 I had a persistent issue with it.
 
 When generating a playlist using AI, there were problems such as:
--
+- Always receiving the same recommendations (the model wasn’t performing web searches)
 
-Always receiving the same recommendations (the model wasn’t performing web searches)
+- Inability to access my last generated playlist
 
--
-
-Inability to access my last generated playlist
-
--
-
-Inability to customize a playlist after generation (required re-generating with a more tailored prompt)
+- Inability to customize a playlist after generation (required re-generating with a more tailored prompt)
 
 So I dove in, cloned the repository, and began tinkering. While AI agents are excellent for navigating new codebases and understanding their structure, I found myself enjoying opening files and tracing cascades of function declarations.
 

--- a/content/substack/open-sourcing.mdx
+++ b/content/substack/open-sourcing.mdx
@@ -25,11 +25,17 @@ The public repository hosts all the extensions available and built by the commun
 I had a persistent issue with it.
 
 When generating a playlist using AI, there were problems such as:
-- Always receiving the same recommendations (the model wasn’t performing web searches)
+-
 
-- Inability to access my last generated playlist
+Always receiving the same recommendations (the model wasn’t performing web searches)
 
-- Inability to customize a playlist after generation (required re-generating with a more tailored prompt)
+-
+
+Inability to access my last generated playlist
+
+-
+
+Inability to customize a playlist after generation (required re-generating with a more tailored prompt)
 
 So I dove in, cloned the repository, and began tinkering. While AI agents are excellent for navigating new codebases and understanding their structure, I found myself enjoying opening files and tracing cascades of function declarations.
 

--- a/content/substack/price-of-losing-focus.mdx
+++ b/content/substack/price-of-losing-focus.mdx
@@ -64,8 +64,6 @@ It was a $3000 investment that felt daunting at first.
 
 Aurelien, my coach, guided me through this haze with tough but meaningful questions. He helped me reconnect with what I truly wanted:
 
->
-
 > To build and create things I love.
 
 Over the weeks, I met incredible people through his network who challenged my thinking and clarified my path.
@@ -79,8 +77,6 @@ Every day, I showed up to trade with a talented mentor. I found immense satisfac
 ![](https://substackcdn.com/image/fetch/$s_!Ig0F!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc92570b4-c011-43f8-be69-6764ffa2d196_1920x1080.png)
 
 Trading might carry a bad reputation for many:
-
->
 
 > • “It’s just gambling.”
 
@@ -115,8 +111,6 @@ You don’t learn this from theory. You learn it from experience, often painful,
 The past year showed me the **cost of losing focus.**
 
 I spent months chasing distractions and new ventures that didn’t align with my passions. But the journey wasn’t a waste. It taught me what truly matters:
-
->
 
 > clarity, resilience, and the courage to stick to what I love.
 

--- a/content/substack/price-of-losing-focus.mdx
+++ b/content/substack/price-of-losing-focus.mdx
@@ -64,6 +64,8 @@ It was a $3000 investment that felt daunting at first.
 
 Aurelien, my coach, guided me through this haze with tough but meaningful questions. He helped me reconnect with what I truly wanted:
 
+>
+
 > To build and create things I love.
 
 Over the weeks, I met incredible people through his network who challenged my thinking and clarified my path.
@@ -77,6 +79,8 @@ Every day, I showed up to trade with a talented mentor. I found immense satisfac
 ![](https://substackcdn.com/image/fetch/$s_!Ig0F!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc92570b4-c011-43f8-be69-6764ffa2d196_1920x1080.png)
 
 Trading might carry a bad reputation for many:
+
+>
 
 > • “It’s just gambling.”
 
@@ -111,6 +115,8 @@ You don’t learn this from theory. You learn it from experience, often painful,
 The past year showed me the **cost of losing focus.**
 
 I spent months chasing distractions and new ventures that didn’t align with my passions. But the journey wasn’t a waste. It taught me what truly matters:
+
+>
 
 > clarity, resilience, and the courage to stick to what I love.
 

--- a/content/substack/taking-time-off.mdx
+++ b/content/substack/taking-time-off.mdx
@@ -82,6 +82,8 @@ Sure, it's hard to unplug at first, that itch to check in. But stick with it, an
 
 So, if you're feeling that pull right now, try it.
 
+>
+
 > Pick one day this week, find your spot, and just be. Sit with your thoughts, reflect on your path. You'll come back stronger, creating with a lightness you haven't felt in ages.
 
 What's your favorite way to step away and reset?

--- a/content/substack/taking-time-off.mdx
+++ b/content/substack/taking-time-off.mdx
@@ -82,8 +82,6 @@ Sure, it's hard to unplug at first, that itch to check in. But stick with it, an
 
 So, if you're feeling that pull right now, try it.
 
->
-
 > Pick one day this week, find your spot, and just be. Sit with your thoughts, reflect on your path. You'll come back stronger, creating with a lightness you haven't felt in ages.
 
 What's your favorite way to step away and reset?

--- a/content/substack/the-importance-of-failure.mdx
+++ b/content/substack/the-importance-of-failure.mdx
@@ -31,15 +31,9 @@ While I was in school, I had big dreams of what I could create once I didn't hav
 I didn't waste time partying, playing video games, or studying endlessly. Instead, I focused on doing my best and unknowingly followed the 80/20 rule. I dedicated time to mastering as much as I could, only realizing later that there's a point where investing too much time becomes less valuable.
 
 Many of my peers didn't follow the same approach. They faced more challenges in their studies, as far as I could see and hear. However, they all eventually earned their diplomas and secured full-time positions at large companies. The point here isn't to judge what's right or wrong; it's about recognizing that there's always an opportunity to accelerate your progress on your journey, and you have the choice:
--
-
-To use the booster and take the shortcut
--
-
-Don’t use it and take the regular path
--
-
-Or, alternatively, you can choose to skip the speed booster, take the shortcut, and run the risk of ending up off course in the end.
+- To use the booster and take the shortcut
+- Don’t use it and take the regular path
+- Or, alternatively, you can choose to skip the speed booster, take the shortcut, and run the risk of ending up off course in the end.
 
 ![Image](https://substackcdn.com/image/fetch/$s_!Pd-z!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ff6fed35a-cfb5-4c23-81e2-6c0d27833f3d_1260x720.webp)
 
@@ -52,8 +46,6 @@ Right now, I'm mainly involved in trading. I attend finance conferences to learn
 I continue to apply to finance firms in search of valuable experience and insights from experts. I'm eager to contribute to their growth and share my ideas.
 
 I started to dream of being part of a team with experienced people and learning with them, and achieving great results. I am a big fan of [Renaissance Technology (Ren Tech), built by James Simons](https://www.rentec.com/Home.action?about=true). This is a hedge fund (now private and open to employees only). They trade using algorithms and quantitative analysis.
-
->
 
 > Quantitative analysis means using math, including equations and rules, to identify relationships between factors and predict how the market may move.
 
@@ -76,28 +68,16 @@ I went through the tasks they gave me during 2-3 hours (I thought it would be th
 After sending my tasks, they said their first impressions were positive, I started envisioning myself as a team member.
 
 But in the end, they decided to not go further with my application. They provided some feedbacks which is appreciated and I agreed with their comments.
--
-
-I didn't utilize pandas/numpy vectorization to its fullest extent, which resulted in a decline in performance (they told me I should have seen this in a quant master degree, and they started doubting about my studies apparently). It's frustrating because I gained extensive knowledge in behavioral finance, Black &amp; Scholes differential equations, machine learning, and regression analysis. However, my teachers never stressed the performance impact of vectorization. Additionally, in this particular task, I didn't see the necessity for it since the dataset was relatively small.** In conclusion, it's crucial to constantly envision how you would tackle the challenges that a company is most likely to face.**
--
-
-Out of the three exercises, I failed to complete the second one entirely because I was in a hurry and didn't realize there was a final part to it. That was my mistake.
--
-
-I didn’t use chatGPT to get insights about how I should have solved the task (strange comment, I didn’t think companies would value the use of chatGPT, and thought they would value more the thinking process).
+- I didn't utilize pandas/numpy vectorization to its fullest extent, which resulted in a decline in performance (they told me I should have seen this in a quant master degree, and they started doubting about my studies apparently). It's frustrating because I gained extensive knowledge in behavioral finance, Black &amp; Scholes differential equations, machine learning, and regression analysis. However, my teachers never stressed the performance impact of vectorization. Additionally, in this particular task, I didn't see the necessity for it since the dataset was relatively small.** In conclusion, it's crucial to constantly envision how you would tackle the challenges that a company is most likely to face.**
+- Out of the three exercises, I failed to complete the second one entirely because I was in a hurry and didn't realize there was a final part to it. That was my mistake.
+- I didn’t use chatGPT to get insights about how I should have solved the task (strange comment, I didn’t think companies would value the use of chatGPT, and thought they would value more the thinking process).
 
 ## The Learning experience and value of failure
 
 Why I value this experience so much?
--
-
-Now, I know more about [vectorization performance increase](https://youtu.be/nxWginnBklU?feature=shared)
--
-
-I understand what people want from an application (code clarity, thought process and performance).
--
-
-I am now more than ever wanting to build my own hedge fund to compete with them and show how valuable I could have been to them.
+- Now, I know more about [vectorization performance increase](https://youtu.be/nxWginnBklU?feature=shared)
+- I understand what people want from an application (code clarity, thought process and performance).
+- I am now more than ever wanting to build my own hedge fund to compete with them and show how valuable I could have been to them.
 
 ## The psychological reaction to failure
 

--- a/content/substack/the-importance-of-failure.mdx
+++ b/content/substack/the-importance-of-failure.mdx
@@ -31,9 +31,15 @@ While I was in school, I had big dreams of what I could create once I didn't hav
 I didn't waste time partying, playing video games, or studying endlessly. Instead, I focused on doing my best and unknowingly followed the 80/20 rule. I dedicated time to mastering as much as I could, only realizing later that there's a point where investing too much time becomes less valuable.
 
 Many of my peers didn't follow the same approach. They faced more challenges in their studies, as far as I could see and hear. However, they all eventually earned their diplomas and secured full-time positions at large companies. The point here isn't to judge what's right or wrong; it's about recognizing that there's always an opportunity to accelerate your progress on your journey, and you have the choice:
-- To use the booster and take the shortcut
-- Don’t use it and take the regular path
-- Or, alternatively, you can choose to skip the speed booster, take the shortcut, and run the risk of ending up off course in the end.
+-
+
+To use the booster and take the shortcut
+-
+
+Don’t use it and take the regular path
+-
+
+Or, alternatively, you can choose to skip the speed booster, take the shortcut, and run the risk of ending up off course in the end.
 
 ![Image](https://substackcdn.com/image/fetch/$s_!Pd-z!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ff6fed35a-cfb5-4c23-81e2-6c0d27833f3d_1260x720.webp)
 
@@ -46,6 +52,8 @@ Right now, I'm mainly involved in trading. I attend finance conferences to learn
 I continue to apply to finance firms in search of valuable experience and insights from experts. I'm eager to contribute to their growth and share my ideas.
 
 I started to dream of being part of a team with experienced people and learning with them, and achieving great results. I am a big fan of [Renaissance Technology (Ren Tech), built by James Simons](https://www.rentec.com/Home.action?about=true). This is a hedge fund (now private and open to employees only). They trade using algorithms and quantitative analysis.
+
+>
 
 > Quantitative analysis means using math, including equations and rules, to identify relationships between factors and predict how the market may move.
 
@@ -68,16 +76,28 @@ I went through the tasks they gave me during 2-3 hours (I thought it would be th
 After sending my tasks, they said their first impressions were positive, I started envisioning myself as a team member.
 
 But in the end, they decided to not go further with my application. They provided some feedbacks which is appreciated and I agreed with their comments.
-- I didn't utilize pandas/numpy vectorization to its fullest extent, which resulted in a decline in performance (they told me I should have seen this in a quant master degree, and they started doubting about my studies apparently). It's frustrating because I gained extensive knowledge in behavioral finance, Black & Scholes differential equations, machine learning, and regression analysis. However, my teachers never stressed the performance impact of vectorization. Additionally, in this particular task, I didn't see the necessity for it since the dataset was relatively small. **In conclusion, it's crucial to constantly envision how you would tackle the challenges that a company is most likely to face.**
-- Out of the three exercises, I failed to complete the second one entirely because I was in a hurry and didn't realize there was a final part to it. That was my mistake.
-- I didn’t use chatGPT to get insights about how I should have solved the task (strange comment, I didn’t think companies would value the use of chatGPT, and thought they would value more the thinking process).
+-
+
+I didn't utilize pandas/numpy vectorization to its fullest extent, which resulted in a decline in performance (they told me I should have seen this in a quant master degree, and they started doubting about my studies apparently). It's frustrating because I gained extensive knowledge in behavioral finance, Black &amp; Scholes differential equations, machine learning, and regression analysis. However, my teachers never stressed the performance impact of vectorization. Additionally, in this particular task, I didn't see the necessity for it since the dataset was relatively small.** In conclusion, it's crucial to constantly envision how you would tackle the challenges that a company is most likely to face.**
+-
+
+Out of the three exercises, I failed to complete the second one entirely because I was in a hurry and didn't realize there was a final part to it. That was my mistake.
+-
+
+I didn’t use chatGPT to get insights about how I should have solved the task (strange comment, I didn’t think companies would value the use of chatGPT, and thought they would value more the thinking process).
 
 ## The Learning experience and value of failure
 
 Why I value this experience so much?
-- Now, I know more about [vectorization performance increase](https://youtu.be/nxWginnBklU?feature=shared)
-- I understand what people want from an application (code clarity, thought process and performance).
-- I am now more than ever wanting to build my own hedge fund to compete with them and show how valuable I could have been to them.
+-
+
+Now, I know more about [vectorization performance increase](https://youtu.be/nxWginnBklU?feature=shared)
+-
+
+I understand what people want from an application (code clarity, thought process and performance).
+-
+
+I am now more than ever wanting to build my own hedge fund to compete with them and show how valuable I could have been to them.
 
 ## The psychological reaction to failure
 

--- a/content/substack/the-importance-of-failure.mdx
+++ b/content/substack/the-importance-of-failure.mdx
@@ -31,15 +31,9 @@ While I was in school, I had big dreams of what I could create once I didn't hav
 I didn't waste time partying, playing video games, or studying endlessly. Instead, I focused on doing my best and unknowingly followed the 80/20 rule. I dedicated time to mastering as much as I could, only realizing later that there's a point where investing too much time becomes less valuable.
 
 Many of my peers didn't follow the same approach. They faced more challenges in their studies, as far as I could see and hear. However, they all eventually earned their diplomas and secured full-time positions at large companies. The point here isn't to judge what's right or wrong; it's about recognizing that there's always an opportunity to accelerate your progress on your journey, and you have the choice:
--
-
-To use the booster and take the shortcut
--
-
-Don’t use it and take the regular path
--
-
-Or, alternatively, you can choose to skip the speed booster, take the shortcut, and run the risk of ending up off course in the end.
+- To use the booster and take the shortcut
+- Don’t use it and take the regular path
+- Or, alternatively, you can choose to skip the speed booster, take the shortcut, and run the risk of ending up off course in the end.
 
 ![Image](https://substackcdn.com/image/fetch/$s_!Pd-z!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ff6fed35a-cfb5-4c23-81e2-6c0d27833f3d_1260x720.webp)
 
@@ -52,8 +46,6 @@ Right now, I'm mainly involved in trading. I attend finance conferences to learn
 I continue to apply to finance firms in search of valuable experience and insights from experts. I'm eager to contribute to their growth and share my ideas.
 
 I started to dream of being part of a team with experienced people and learning with them, and achieving great results. I am a big fan of [Renaissance Technology (Ren Tech), built by James Simons](https://www.rentec.com/Home.action?about=true). This is a hedge fund (now private and open to employees only). They trade using algorithms and quantitative analysis.
-
->
 
 > Quantitative analysis means using math, including equations and rules, to identify relationships between factors and predict how the market may move.
 
@@ -76,28 +68,16 @@ I went through the tasks they gave me during 2-3 hours (I thought it would be th
 After sending my tasks, they said their first impressions were positive, I started envisioning myself as a team member.
 
 But in the end, they decided to not go further with my application. They provided some feedbacks which is appreciated and I agreed with their comments.
--
-
-I didn't utilize pandas/numpy vectorization to its fullest extent, which resulted in a decline in performance (they told me I should have seen this in a quant master degree, and they started doubting about my studies apparently). It's frustrating because I gained extensive knowledge in behavioral finance, Black &amp; Scholes differential equations, machine learning, and regression analysis. However, my teachers never stressed the performance impact of vectorization. Additionally, in this particular task, I didn't see the necessity for it since the dataset was relatively small.** In conclusion, it's crucial to constantly envision how you would tackle the challenges that a company is most likely to face.**
--
-
-Out of the three exercises, I failed to complete the second one entirely because I was in a hurry and didn't realize there was a final part to it. That was my mistake.
--
-
-I didn’t use chatGPT to get insights about how I should have solved the task (strange comment, I didn’t think companies would value the use of chatGPT, and thought they would value more the thinking process).
+- I didn't utilize pandas/numpy vectorization to its fullest extent, which resulted in a decline in performance (they told me I should have seen this in a quant master degree, and they started doubting about my studies apparently). It's frustrating because I gained extensive knowledge in behavioral finance, Black & Scholes differential equations, machine learning, and regression analysis. However, my teachers never stressed the performance impact of vectorization. Additionally, in this particular task, I didn't see the necessity for it since the dataset was relatively small. **In conclusion, it's crucial to constantly envision how you would tackle the challenges that a company is most likely to face.**
+- Out of the three exercises, I failed to complete the second one entirely because I was in a hurry and didn't realize there was a final part to it. That was my mistake.
+- I didn’t use chatGPT to get insights about how I should have solved the task (strange comment, I didn’t think companies would value the use of chatGPT, and thought they would value more the thinking process).
 
 ## The Learning experience and value of failure
 
 Why I value this experience so much?
--
-
-Now, I know more about [vectorization performance increase](https://youtu.be/nxWginnBklU?feature=shared)
--
-
-I understand what people want from an application (code clarity, thought process and performance).
--
-
-I am now more than ever wanting to build my own hedge fund to compete with them and show how valuable I could have been to them.
+- Now, I know more about [vectorization performance increase](https://youtu.be/nxWginnBklU?feature=shared)
+- I understand what people want from an application (code clarity, thought process and performance).
+- I am now more than ever wanting to build my own hedge fund to compete with them and show how valuable I could have been to them.
 
 ## The psychological reaction to failure
 

--- a/content/substack/ticking-life-goals.mdx
+++ b/content/substack/ticking-life-goals.mdx
@@ -65,15 +65,9 @@ Obstacle two: no house and needing space before the baby arrived. We prioritized
 Obstacle three: extreme stress and fear of burnout. I committed to running nearly every day, set strict sleep windows when I could, and leaned on my partner for emotional support and practical planning.
 
 Small wins built up.
-1.
-
-The runs kept me steady.
-1.
-
-The product traction made banks take us seriously.
-1.
-
-The savings lowered risk.
+1. The runs kept me steady.
+1. The product traction made banks take us seriously.
+1. The savings lowered risk.
 
 Together, they created the conditions to buy the house before our baby came.
 
@@ -86,21 +80,11 @@ It’s about lining up small, repeatable actions with one clear North Star.
 Here’s what worked:
 
 Keep one North Star. It makes trade-offs easier and cuts down decision fatigue.
--
-
-Use a physical routine as mental rehearsal: running for me, to keep that North Star alive, especially when things get tough.
--
-
-Focus on high-leverage work, not busy lists. What moves the needle? What pays the bills?
--
-
-Temporary trade-offs are okay if they lead to lasting wins: tight budgets now for a home later.
--
-
-Negotiation and persistence pay off. Shop around, show your numbers, be ready.
--
-
-Define good health simply: no physical harm and the capacity to enjoy life. Protect that like it’s sacred.
+- Use a physical routine as mental rehearsal: running for me, to keep that North Star alive, especially when things get tough.
+- Focus on high-leverage work, not busy lists. What moves the needle? What pays the bills?
+- Temporary trade-offs are okay if they lead to lasting wins: tight budgets now for a home later.
+- Negotiation and persistence pay off. Shop around, show your numbers, be ready.
+- Define good health simply: no physical harm and the capacity to enjoy life. Protect that like it’s sacred.
 
 If you want to try this, here’s a simple monthly “tickable goals” template I use:
 

--- a/content/substack/ticking-life-goals.mdx
+++ b/content/substack/ticking-life-goals.mdx
@@ -65,9 +65,15 @@ Obstacle two: no house and needing space before the baby arrived. We prioritized
 Obstacle three: extreme stress and fear of burnout. I committed to running nearly every day, set strict sleep windows when I could, and leaned on my partner for emotional support and practical planning.
 
 Small wins built up.
-1. The runs kept me steady.
-1. The product traction made banks take us seriously.
-1. The savings lowered risk.
+1.
+
+The runs kept me steady.
+1.
+
+The product traction made banks take us seriously.
+1.
+
+The savings lowered risk.
 
 Together, they created the conditions to buy the house before our baby came.
 
@@ -80,11 +86,21 @@ It’s about lining up small, repeatable actions with one clear North Star.
 Here’s what worked:
 
 Keep one North Star. It makes trade-offs easier and cuts down decision fatigue.
-- Use a physical routine as mental rehearsal: running for me, to keep that North Star alive, especially when things get tough.
-- Focus on high-leverage work, not busy lists. What moves the needle? What pays the bills?
-- Temporary trade-offs are okay if they lead to lasting wins: tight budgets now for a home later.
-- Negotiation and persistence pay off. Shop around, show your numbers, be ready.
-- Define good health simply: no physical harm and the capacity to enjoy life. Protect that like it’s sacred.
+-
+
+Use a physical routine as mental rehearsal: running for me, to keep that North Star alive, especially when things get tough.
+-
+
+Focus on high-leverage work, not busy lists. What moves the needle? What pays the bills?
+-
+
+Temporary trade-offs are okay if they lead to lasting wins: tight budgets now for a home later.
+-
+
+Negotiation and persistence pay off. Shop around, show your numbers, be ready.
+-
+
+Define good health simply: no physical harm and the capacity to enjoy life. Protect that like it’s sacred.
 
 If you want to try this, here’s a simple monthly “tickable goals” template I use:
 

--- a/content/substack/to-reach-the-top.mdx
+++ b/content/substack/to-reach-the-top.mdx
@@ -26,8 +26,6 @@ I don’t think it buys joy, but it does buy the absence of the specific anxieti
 
 However, we often treat the pyramid like a rigid ladder where you must finish one level before starting the next.
 
->
-
 > But Maslow himself noted that we don’t need to be 100 % secure to start looking for meaning; we are often partially satisfied and partially unsatisfied in all our needs at the same time.
 
 Life is full of surprises, challenges, and opportunities. I recently watched [Eric Dane’s "last words"](https://youtu.be/sEMpdwdVpng?si=f-FLEv5bx10c_POd), and it struck me: the most important thing in life is to find what (or who) you love, and to fight for that.

--- a/content/substack/to-reach-the-top.mdx
+++ b/content/substack/to-reach-the-top.mdx
@@ -26,6 +26,8 @@ I don’t think it buys joy, but it does buy the absence of the specific anxieti
 
 However, we often treat the pyramid like a rigid ladder where you must finish one level before starting the next.
 
+>
+
 > But Maslow himself noted that we don’t need to be 100 % secure to start looking for meaning; we are often partially satisfied and partially unsatisfied in all our needs at the same time.
 
 Life is full of surprises, challenges, and opportunities. I recently watched [Eric Dane’s "last words"](https://youtu.be/sEMpdwdVpng?si=f-FLEv5bx10c_POd), and it struck me: the most important thing in life is to find what (or who) you love, and to fight for that.

--- a/content/substack/using-the-blockchain.mdx
+++ b/content/substack/using-the-blockchain.mdx
@@ -32,6 +32,8 @@ Indeed, before doing anything serious, let’s understand what it is, why the pr
 
 First, a crypto “currency” couldn't be called a currency if it is not allowing you to buy something with it. Today, fortunately, you can buy things on the internet using cryptos thanks to actors like Coinbase and their wallet integration on e-commerce websites.
 
+>
+
 > As an example, I have bought a real cap using cryptos and NFT:
 
 ![](https://substackcdn.com/image/fetch/$s_!B5jg!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fa76581bc-4fcf-46b4-aeae-de9b9e1ca0c0.heic)
@@ -76,11 +78,15 @@ A blockchain is a database on the form of a linked list (in programming). You ca
 
 A layer 2 is a blockchain on top of another blockchain (layer 1) which most of the time allows the use of an original blockchain at higher speed or lower cost.
 
+>
+
 > I am quite against layer 2 because I think we should spend time improving the main blockchain than developing another blockchain on top of another (if the main fails, what the point of it?).
 
 > However, I understand that people build layer 2 because they consider the main blockchain “reliable” enough and also because they might be constrained from the maintainers of the original blockchain (who don’t want to change their original code).
 
 As an example, regarding Ethereum, there is a core team of maintainers (including the famous [Vitalik Buterin](https://vitalik.eth.limo/general/2023/11/27/techno_optimism.html)) who develops the blockchain and accepts suggestions from the community. Layers 2 like [Arbitrum](https://arbitrum.io) and [Optimism](https://www.optimism.io), which allow people to build ontop of Ethereum at lower costs or higher speeds.
+
+>
 
 > There has recently been upgrades to the Ethereum blockchain which will ultimately leads to the death of L2 (in my opinion). Indeed, core maintainers are trying to make Ethereum faster, cheaper and “greener”.
 

--- a/content/substack/using-the-blockchain.mdx
+++ b/content/substack/using-the-blockchain.mdx
@@ -32,8 +32,6 @@ Indeed, before doing anything serious, let’s understand what it is, why the pr
 
 First, a crypto “currency” couldn't be called a currency if it is not allowing you to buy something with it. Today, fortunately, you can buy things on the internet using cryptos thanks to actors like Coinbase and their wallet integration on e-commerce websites.
 
->
-
 > As an example, I have bought a real cap using cryptos and NFT:
 
 ![](https://substackcdn.com/image/fetch/$s_!B5jg!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fa76581bc-4fcf-46b4-aeae-de9b9e1ca0c0.heic)
@@ -78,15 +76,11 @@ A blockchain is a database on the form of a linked list (in programming). You ca
 
 A layer 2 is a blockchain on top of another blockchain (layer 1) which most of the time allows the use of an original blockchain at higher speed or lower cost.
 
->
-
 > I am quite against layer 2 because I think we should spend time improving the main blockchain than developing another blockchain on top of another (if the main fails, what the point of it?).
 
 > However, I understand that people build layer 2 because they consider the main blockchain “reliable” enough and also because they might be constrained from the maintainers of the original blockchain (who don’t want to change their original code).
 
 As an example, regarding Ethereum, there is a core team of maintainers (including the famous [Vitalik Buterin](https://vitalik.eth.limo/general/2023/11/27/techno_optimism.html)) who develops the blockchain and accepts suggestions from the community. Layers 2 like [Arbitrum](https://arbitrum.io) and [Optimism](https://www.optimism.io), which allow people to build ontop of Ethereum at lower costs or higher speeds.
-
->
 
 > There has recently been upgrades to the Ethereum blockchain which will ultimately leads to the death of L2 (in my opinion). Indeed, core maintainers are trying to make Ethereum faster, cheaper and “greener”.
 

--- a/content/substack/we-cant-handle-everything.mdx
+++ b/content/substack/we-cant-handle-everything.mdx
@@ -52,6 +52,8 @@ Today, I am driven by statistics and journaling for trading.
 
 My motivation is clear:
 
+>
+
 > Provide a tool for traders to track their progress and reflect on their data to become profitable and consistent.
 
 I am a trader myself; at least, I consider myself a trader. For 14 months now, I have been trading daily, getting $6,500 out of trading accounts from prop firms in which I have invested $2,500 (trading tools included).

--- a/content/substack/we-cant-handle-everything.mdx
+++ b/content/substack/we-cant-handle-everything.mdx
@@ -52,8 +52,6 @@ Today, I am driven by statistics and journaling for trading.
 
 My motivation is clear:
 
->
-
 > Provide a tool for traders to track their progress and reflect on their data to become profitable and consistent.
 
 I am a trader myself; at least, I consider myself a trader. For 14 months now, I have been trading daily, getting $6,500 out of trading accounts from prop firms in which I have invested $2,500 (trading tools included).

--- a/content/substack/wont-you-take-a-break.mdx
+++ b/content/substack/wont-you-take-a-break.mdx
@@ -40,6 +40,8 @@ Running clears my mind and keeps me grounded.
 
 Some entrepreneurs in our group have faced burnout. It’s a clear reminder: if you want to last, you need to prioritize your health.
 
+>
+
 > •**> Research Support**> : Studies show that entrepreneurs are more prone to mental health issues than the general population. For instance, research by Dr. Michael A. Freeman from UC Berkeley reveals that 50% of entrepreneurs report mental health struggles, making self-care essential for sustainability.
 
 ## **Winter is coming**
@@ -57,6 +59,8 @@ Winter can show up as difficulty finding clients, low revenue, or the exhaustion
 It’s also those nights when you can’t sleep because your mind is buzzing with tasks you haven’t tackled.
 
 For these reasons, entrepreneurship isn’t for everyone. It takes commitment and a lot of mental strength.
+
+>
 
 > •**> Research Support**> : The Kauffman Foundation reports that early entrepreneurial phases often include extended “winters” due to unstable revenue and high workload. Similarly, Harvard Business Review describes the entrepreneurial journey as a cyclical one, with inevitable phases of struggle and downturn.
 

--- a/content/substack/wont-you-take-a-break.mdx
+++ b/content/substack/wont-you-take-a-break.mdx
@@ -40,8 +40,6 @@ Running clears my mind and keeps me grounded.
 
 Some entrepreneurs in our group have faced burnout. It’s a clear reminder: if you want to last, you need to prioritize your health.
 
->
-
 > •**> Research Support**> : Studies show that entrepreneurs are more prone to mental health issues than the general population. For instance, research by Dr. Michael A. Freeman from UC Berkeley reveals that 50% of entrepreneurs report mental health struggles, making self-care essential for sustainability.
 
 ## **Winter is coming**
@@ -59,8 +57,6 @@ Winter can show up as difficulty finding clients, low revenue, or the exhaustion
 It’s also those nights when you can’t sleep because your mind is buzzing with tasks you haven’t tackled.
 
 For these reasons, entrepreneurship isn’t for everyone. It takes commitment and a lot of mental strength.
-
->
 
 > •**> Research Support**> : The Kauffman Foundation reports that early entrepreneurial phases often include extended “winters” due to unstable revenue and high workload. Similarly, Harvard Business Review describes the entrepreneurial journey as a cyclical one, with inevitable phases of struggle and downturn.
 

--- a/lib/html-to-markdown.test.ts
+++ b/lib/html-to-markdown.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { htmlToMarkdown } from "./html-to-markdown";
+
+test("keeps Substack list items on one line so they are not setext headings", () => {
+  const markdown = htmlToMarkdown(
+    "<p>You have the choice:</p><ul><li><p>To use the booster and take the shortcut</p></li><li><p>Don’t use it and take the regular path</p></li></ul>"
+  );
+
+  assert.equal(
+    markdown,
+    [
+      "You have the choice:",
+      "",
+      "- To use the booster and take the shortcut",
+      "- Don’t use it and take the regular path",
+    ].join("\n")
+  );
+  assert.doesNotMatch(markdown, /^-\s*$/m);
+});
+
+test("keeps numbered Substack lists attached to their text", () => {
+  const markdown = htmlToMarkdown(
+    "<p>Small wins built up.</p><ol><li><p>The runs kept me steady.</p></li><li><p>The savings lowered risk.</p></li></ol>"
+  );
+
+  assert.equal(
+    markdown,
+    [
+      "Small wins built up.",
+      "",
+      "1. The runs kept me steady.",
+      "1. The savings lowered risk.",
+    ].join("\n")
+  );
+});
+
+test("does not emit an empty blockquote line before quoted text", () => {
+  const markdown = htmlToMarkdown(
+    "<blockquote><p>Quantitative analysis means using math.</p></blockquote>"
+  );
+
+  assert.equal(markdown, "> Quantitative analysis means using math.");
+});
+
+test("decodes HTML entities in body text", () => {
+  const markdown = htmlToMarkdown(
+    "<p>Black &amp; Scholes differential equations</p>"
+  );
+
+  assert.equal(markdown, "Black & Scholes differential equations");
+});
+
+test("leaves a space before bold that starts after a period", () => {
+  const markdown = htmlToMarkdown(
+    "<p>The dataset was relatively small. <strong>In conclusion, envision the challenges.</strong></p>"
+  );
+
+  assert.equal(
+    markdown,
+    "The dataset was relatively small. **In conclusion, envision the challenges.**"
+  );
+});

--- a/lib/html-to-markdown.test.ts
+++ b/lib/html-to-markdown.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { htmlToMarkdown } from "./html-to-markdown";
+import {
+  htmlToMarkdown,
+  repairDetachedMarkdownMarkers,
+} from "./html-to-markdown";
 
 test("keeps Substack list items on one line so they are not setext headings", () => {
   const markdown = htmlToMarkdown(
@@ -49,6 +52,29 @@ test("decodes HTML entities in body text", () => {
   );
 
   assert.equal(markdown, "Black & Scholes differential equations");
+});
+
+test("reattaches list markers already stored in synced markdown", () => {
+  const repaired = repairDetachedMarkdownMarkers(
+    [
+      "Why I value this experience so much?",
+      "-",
+      "",
+      "Now, I know more about vectorization",
+      "-",
+      "",
+      "I understand what people want",
+    ].join("\n")
+  );
+
+  assert.equal(
+    repaired,
+    [
+      "Why I value this experience so much?",
+      "- Now, I know more about vectorization",
+      "- I understand what people want",
+    ].join("\n")
+  );
 });
 
 test("leaves a space before bold that starts after a period", () => {

--- a/lib/html-to-markdown.ts
+++ b/lib/html-to-markdown.ts
@@ -787,8 +787,7 @@ function postProcessMarkdown(markdown: string): string {
 
 /**
  * Substack's HTML-to-Markdown sync used to emit list/quote markers on their
- * own line. Markdown then treats "paragraph\\n-" as a setext heading. Reattach
- * those markers at read time so already-synced .mdx files do not need edits.
+ * own line. Markdown then treats "paragraph\\n-" as a setext heading.
  */
 export function repairDetachedMarkdownMarkers(markdown: string): string {
   return markdown

--- a/lib/html-to-markdown.ts
+++ b/lib/html-to-markdown.ts
@@ -115,6 +115,32 @@ function tokenize(html: string): Token[] {
 /**
  * Converts HTML tokens to Markdown string.
  */
+const HTML_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+function decodeHtmlEntities(text: string): string {
+  return text.replace(/&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z]+);/g, (match, entity) => {
+    if (entity[0] === "#") {
+      const codePoint =
+        entity[1] === "x" || entity[1] === "X"
+          ? parseInt(entity.slice(2), 16)
+          : parseInt(entity.slice(1), 10);
+      return Number.isNaN(codePoint) ? match : String.fromCodePoint(codePoint);
+    }
+    return HTML_ENTITIES[entity] ?? match;
+  });
+}
+
+function endsWithBlockPrefix(value: string): boolean {
+  return /(^|\n)(?:> |(?:-|\d+\.) )$/.test(value);
+}
+
 function tokensToMarkdown(tokens: Token[]): string {
   const output: string[] = [];
   let i = 0;
@@ -126,7 +152,7 @@ function tokensToMarkdown(tokens: Token[]): string {
     if (!last || typeof last !== "string") return;
     if (last.endsWith(" ") || last.endsWith("\n")) return;
     const lastChar = last[last.length - 1];
-    if (lastChar && /[a-zA-Z0-9]/.test(lastChar)) {
+    if (lastChar && /[a-zA-Z0-9.!?,:;]/.test(lastChar)) {
       output.push(" ");
     }
   }
@@ -205,7 +231,7 @@ function tokensToMarkdown(tokens: Token[]): string {
       if (!isInCodeBlock() && token.content) {
         // Normalize whitespace: collapse multiple spaces/tabs/newlines to single space
         // But preserve the text content
-        let text = token.content.replace(/[\s]+/g, " ");
+        let text = decodeHtmlEntities(token.content.replace(/[\s]+/g, " "));
         
         // Only process if there's actual content (not just whitespace)
         if (text.trim()) {
@@ -482,10 +508,18 @@ function tokensToMarkdown(tokens: Token[]): string {
         }
 
         case "p": {
+          // Substack wraps every list item and blockquote in <p>. Extra blank
+          // lines after "- " / "> " turn those markers into setext headings
+          // ("paragraph\\n-") or an empty quote line.
+          const last = output.length > 0 ? output[output.length - 1] : "";
+          if (typeof last === "string" && endsWithBlockPrefix(last)) {
+            stack.push(token);
+            break;
+          }
+
           // When opening a paragraph, ensure we have proper spacing
           // If previous output doesn't end with \n\n, add it
           if (output.length > 0) {
-            const last = output[output.length - 1];
             if (typeof last === "string") {
               if (!last.endsWith("\n\n")) {
                 // If it ends with \n, modify the last item to add one more \n (make it \n\n)
@@ -589,8 +623,15 @@ function tokensToMarkdown(tokens: Token[]): string {
 
         case "ul":
         case "ol": {
-          if (output.length > 0 && !output[output.length - 1]?.endsWith("\n")) {
-            output.push("\n");
+          if (output.length > 0) {
+            const last = output[output.length - 1];
+            if (typeof last === "string" && !last.endsWith("\n\n")) {
+              if (last.endsWith("\n")) {
+                output[output.length - 1] = last + "\n";
+              } else {
+                output.push("\n\n");
+              }
+            }
           }
           if (!selfClosing) stack.push(token);
           break;
@@ -737,6 +778,11 @@ function postProcessMarkdown(markdown: string): string {
       // If a closing marker is immediately followed by a word char, add a space
       .replace(/(?<=\S)\*\*(?=[a-zA-Z0-9])/g, "** ")
       .replace(/(\))([a-zA-Z0-9])/g, "$1 $2")
+      // Lone list/quote markers on their own line become setext headings or
+      // empty quotes. Keep the marker attached to the following text.
+      .replace(/(^|\n)-\n+/g, "$1- ")
+      .replace(/(^|\n)(\d+)\.\n+/g, "$1$2. ")
+      .replace(/(^|\n)>\n+(?:>[ \t]*)?/g, "$1> ")
       .replace(/\n{3,}/g, "\n\n")
       .replace(/[ \t]+\n/g, "\n")
       .replace(/[ \t]{2,}/g, " ")

--- a/lib/html-to-markdown.ts
+++ b/lib/html-to-markdown.ts
@@ -763,7 +763,7 @@ export function htmlToMarkdown(html: string): string {
     .trim();
 
   const tokens = tokenize(cleaned);
-  return postProcessMarkdown(tokensToMarkdown(tokens));
+  return repairDetachedMarkdownMarkers(postProcessMarkdown(tokensToMarkdown(tokens)));
 }
 
 function postProcessMarkdown(markdown: string): string {
@@ -778,15 +778,22 @@ function postProcessMarkdown(markdown: string): string {
       // If a closing marker is immediately followed by a word char, add a space
       .replace(/(?<=\S)\*\*(?=[a-zA-Z0-9])/g, "** ")
       .replace(/(\))([a-zA-Z0-9])/g, "$1 $2")
-      // Lone list/quote markers on their own line become setext headings or
-      // empty quotes. Keep the marker attached to the following text.
-      .replace(/(^|\n)-\n+/g, "$1- ")
-      .replace(/(^|\n)(\d+)\.\n+/g, "$1$2. ")
-      .replace(/(^|\n)>\n+(?:>[ \t]*)?/g, "$1> ")
       .replace(/\n{3,}/g, "\n\n")
       .replace(/[ \t]+\n/g, "\n")
       .replace(/[ \t]{2,}/g, " ")
       .trim()
   );
+}
+
+/**
+ * Substack's HTML-to-Markdown sync used to emit list/quote markers on their
+ * own line. Markdown then treats "paragraph\\n-" as a setext heading. Reattach
+ * those markers at read time so already-synced .mdx files do not need edits.
+ */
+export function repairDetachedMarkdownMarkers(markdown: string): string {
+  return markdown
+    .replace(/(^|\n)-\n+/g, "$1- ")
+    .replace(/(^|\n)(\d+)\.\n+/g, "$1$2. ")
+    .replace(/(^|\n)>\n+(?:>[ \t]*)?/g, "$1> ");
 }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "start": "next start",
     "sync-substack": "tsx scripts/sync-substack-posts.ts",
-    "test": "tsx --test server/location-data.test.ts server/location.test.ts server/shape.test.ts server/spotify.test.ts server/spotify-cron.test.ts server/vercel-env.test.ts lib/location-display.test.ts lib/run-areas.test.ts lib/shape-runs.test.ts lib/stamp-album.test.ts lib/stamp-pose.test.ts lib/stamp-visibility.test.ts lib/world-map.test.ts app/api/location/update/route.test.ts app/api/spotify/authorize/route.test.ts app/api/spotify/callback/route.test.ts"
+    "test": "tsx --test server/location-data.test.ts server/location.test.ts server/shape.test.ts server/spotify.test.ts server/spotify-cron.test.ts server/vercel-env.test.ts lib/html-to-markdown.test.ts lib/location-display.test.ts lib/run-areas.test.ts lib/shape-runs.test.ts lib/stamp-album.test.ts lib/stamp-pose.test.ts lib/stamp-visibility.test.ts lib/world-map.test.ts app/api/location/update/route.test.ts app/api/spotify/authorize/route.test.ts app/api/spotify/callback/route.test.ts"
   },
   "dependencies": {
     "@next/mdx": "^16.0.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Substack wraps every list item in a `<p>`. The HTML-to-Markdown converter put the `-` / `1.` marker on its own line, and Markdown then treated the previous paragraph as a setext heading.

That is why [The importance of failure](https://www.hugodemenez.fr/posts/the-importance-of-failure) stacked huge headings: lines like “Why I value this experience so much?” were parsed as `h2`s.

## Approach
Apply the repair once to the stored posts. No extra work runs when a page is compiled.

- The HTML converter now emits correct list/quote markdown for future syncs
- Already-synced `.mdx` files get the same marker repair written in

## Changes
- Keep list and blockquote markers attached to their text in `htmlToMarkdown`
- Decode HTML entities and leave a space before bold that starts after a period
- Repair detached `-` / `1.` / `>` markers in the 25 already-synced posts
- Add converter tests for the Substack list/quote cases

## Walkthrough
The learning-experience section now reads as a short intro plus a normal bullet list.

![Learning-experience section on mobile, light mode](https://cursor.com/artifacts/c/art-892e7276-aa0c-4437-8316-63ea906c157d)

![Learning-experience section on mobile, dark mode](https://cursor.com/artifacts/c/art-9d95d3d7-41cd-40cb-9b79-00bd800902ed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00565-78dd-72b1-88de-a01d1ca1b057?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00565-78dd-72b1-88de-a01d1ca1b057&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

