### PR TITLE
Paint the earliest run before the rest animate

### DIFF
--- a/app/_components/path-map.tsx
+++ b/app/_components/path-map.tsx
@@ -26,10 +26,13 @@ export function PathMap({ sketch }: { sketch: PathSketch }) {
     if (!node) return;
 
     const paths = [...node.querySelectorAll("path")];
-    const hide = () => {
-      for (const path of paths) {
+    // The first stroke is the earliest run. Keep it painted so a path is
+    // visible before the later loops start drawing.
+    const animated = paths.slice(1);
+    const reset = () => {
+      for (const [index, path] of paths.entries()) {
         path.style.strokeDasharray = "1";
-        path.style.strokeDashoffset = "1";
+        path.style.strokeDashoffset = index === 0 ? "0" : "1";
       }
     };
     const reveal = () => {
@@ -38,7 +41,7 @@ export function PathMap({ sketch }: { sketch: PathSketch }) {
       }
     };
 
-    hide();
+    reset();
 
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
       reveal();
@@ -48,9 +51,11 @@ export function PathMap({ sketch }: { sketch: PathSketch }) {
 
     const play = () => {
       cancelAnimationFrame(frameRef.current);
-      hide();
+      reset();
 
-      const durations = drawDurations(paths.length, DRAW_BUDGET_MS);
+      if (!animated.length) return;
+
+      const durations = drawDurations(animated.length, DRAW_BUDGET_MS);
       const starts: number[] = [];
       let mark = 0;
       for (const duration of durations) {
@@ -62,7 +67,7 @@ export function PathMap({ sketch }: { sketch: PathSketch }) {
       const tick = (now: number) => {
         const elapsed = now - begin;
 
-        paths.forEach((path, index) => {
+        animated.forEach((path, index) => {
           const duration = durations[index] ?? 1;
           const local = (elapsed - (starts[index] ?? 0)) / duration;
           const progress = Math.min(1, Math.max(0, local));
@@ -98,7 +103,7 @@ export function PathMap({ sketch }: { sketch: PathSketch }) {
       ([entry]) => {
         if (entry.isIntersecting) return;
         cancelAnimationFrame(frameRef.current);
-        hide();
+        reset();
       },
       { threshold: 0 }
     );
@@ -126,7 +131,7 @@ export function PathMap({ sketch }: { sketch: PathSketch }) {
       shapeRendering="geometricPrecision"
       viewBox={`0 0 ${sketch.width} ${sketch.height}`}
     >
-      {sketch.traces.map((trace) => (
+      {sketch.traces.map((trace, index) => (
         <path
           d={trace}
           key={trace}
@@ -134,7 +139,7 @@ export function PathMap({ sketch }: { sketch: PathSketch }) {
           pathLength="1"
           stroke="currentColor"
           strokeDasharray="1"
-          strokeDashoffset="1"
+          strokeDashoffset={index === 0 ? "0" : "1"}
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.2"
@@ -146,7 +151,7 @@ export function PathMap({ sketch }: { sketch: PathSketch }) {
         pathLength="1"
         stroke="currentColor"
         strokeDasharray="1"
-        strokeDashoffset="1"
+        strokeDashoffset={sketch.traces.length === 0 ? "0" : "1"}
         strokeLinecap="round"
         strokeLinejoin="round"
         strokeWidth="1.7"

--- a/lib/shape-runs.test.ts
+++ b/lib/shape-runs.test.ts
@@ -251,6 +251,32 @@ test("sketchRoutes draws the latest loop and faint traces of the others", () => 
   assert.equal(sketch?.traces.length, 1);
 });
 
+test("sketchRoutes lists faint traces oldest first", () => {
+  const latest: Array<[number, number]> = [
+    [38.553, -9.018],
+    [38.554, -9.016],
+    [38.552, -9.015],
+  ];
+  const middle: Array<[number, number]> = [
+    [38.553, -9.018],
+    [38.554, -9.017],
+    [38.551, -9.016],
+  ];
+  const oldest: Array<[number, number]> = [
+    [38.553, -9.018],
+    [38.552, -9.016],
+    [38.551, -9.017],
+  ];
+
+  const all = sketchRoutes([latest, middle, oldest]);
+  const withoutMiddle = sketchRoutes([latest, oldest]);
+  const withoutOldest = sketchRoutes([latest, middle]);
+
+  assert.equal(all?.traces.length, 2);
+  assert.equal(all?.traces[0], withoutMiddle?.traces[0]);
+  assert.equal(all?.traces[1], withoutOldest?.traces[0]);
+});
+
 test("sketchRoutes keeps every drawn route inside the viewBox", () => {
   const short: Array<[number, number]> = [
     [50.665, 3.166],

--- a/lib/shape-runs.ts
+++ b/lib/shape-runs.ts
@@ -285,7 +285,10 @@ export function sketchRoutes(
         SKETCH_PADDING
       )
     )
-    .filter((trace): trace is string => Boolean(trace));
+    .filter((trace): trace is string => Boolean(trace))
+    // Oldest first so the earliest loop sits under later traces and can
+    // be painted immediately while the rest still draw in sequence.
+    .reverse();
 
   return { width, height, path, traces };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Route cards used to hide every stroke until the mid-screen draw sequence started, so a path only appeared after the animation began.

This keeps the oldest loop painted from the first frame. Later traces still draw in chronological order, and the latest loop remains the accent stroke.

- `sketchRoutes` lists faint traces oldest-first so the earliest run sits under the rest
- `PathMap` leaves that first stroke visible on paint, reset, and replay
- Cards with a single run show it immediately instead of waiting for the observer

### Screenshots

Light:

![Running cards in light mode, earliest paths already painted](https://cursor.com/artifacts/c/art-f524e874-b443-4f16-8b1d-87aeeb7822f0)

Dark:

![Running cards in dark mode, earliest paths already painted](https://cursor.com/artifacts/c/art-1ec88e2f-7e8d-4724-b954-ddd57bc5b5c9)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00614-d14e-75e6-b38f-2f217ee2494c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00614-d14e-75e6-b38f-2f217ee2494c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

